### PR TITLE
use eager_load in application config

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -13,9 +13,7 @@ end
 module RubyChina
   class Application < Rails::Application
     # Custom directories with classes and modules you want to be autoloadable.
-    config.autoload_paths += %W(#{config.root}/uploaders)
-    config.autoload_paths += %W(#{config.root}/lib)
-    config.autoload_paths += %W(#{config.root}/app/grape)
+    config.eager_load_paths += %W(#{config.root}/uploaders)
 
     config.time_zone = 'Beijing'
 


### PR DESCRIPTION
Inspired by http://blog.arkency.com/2014/11/dont-forget-about-eager-load-when-extending-autoload/.
`eager_load_paths` is also eager loaded in production mode

> Unfortunately I’ve seen many people doing things like
config.autoload_paths += %W( #{config.root}/app/services )
config.autoload_paths += %W( #{config.root}/app/presenters )
It is completely unnecessary because app/* is already added there. 

You can see the default rails 4.1.7 paths configuration
```ruby
def paths
  @paths ||= begin
    paths = Rails::Paths::Root.new(@root)

    paths.add "app",                 eager_load: true, glob: "*"
    paths.add "app/assets",          glob: "*"
    paths.add "app/controllers",     eager_load: true
    paths.add "app/helpers",         eager_load: true
    paths.add "app/models",          eager_load: true
    paths.add "app/mailers",         eager_load: true
    paths.add "app/views"

    paths.add "app/controllers/concerns", eager_load: true
    paths.add "app/models/concerns",      eager_load: true

    paths.add "lib",                 load_path: true
    paths.add "lib/assets",          glob: "*"
    paths.add "lib/tasks",           glob: "**/*.rake"

    paths.add "config"
    paths.add "config/environments", glob: "#{Rails.env}.rb"
    paths.add "config/initializers", glob: "**/*.rb"
    paths.add "config/locales",      glob: "*.{rb,yml}"
    paths.add "config/routes.rb"

    paths.add "db"
    paths.add "db/migrate"
    paths.add "db/seeds.rb"

    paths.add "vendor",              load_path: true
    paths.add "vendor/assets",       glob: "*"

    paths
  end
end
```