### PR TITLE
fix_image_too_big_in_user_page_reply_tab

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -134,3 +134,9 @@ table.node-topics {
     .desc { font-size:12px; color:#888; }
   }
 }
+
+.body {
+  img{ 
+    max-width: 100%;
+  }
+}


### PR DESCRIPTION
用户个人页面，查看回复帖子的图片太大了，没有限制。

比如这个页面:
https://ruby-china.org/joycehan
