### PR TITLE
use nan.so/rubychina as google search

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -52,7 +52,7 @@
 
         <ul class="nav navbar-nav navbar-right">
           <li class="nav-search hidden-xs">
-            <form class="navbar-form form-search" action="/search" method="GET">
+            <form class="navbar-form form-search" action="http://nan.so/rubychina" method="GET">
               <div class="form-group">
                 <input class="form-control" name="q" type="text" value="<%= params[:q] %>" placeholder="搜索本站内容" />
               </div>


### PR DESCRIPTION
Google在未翻墙情况下无法使用，nan.so是Google的一个镜像，部署在阿里云上，可以作为搜索的替代方案。