### PR TITLE
修复微信浏览器中打开ruby-china页面样式问题 #397 

### DIFF
--- a/app/assets/javascripts/turbolinks.js
+++ b/app/assets/javascripts/turbolinks.js
@@ -844,7 +844,7 @@ ProgressBar = (function() {
   };
 
   ProgressBar.prototype._createCSSRule = function() {
-    return "" + this.elementSelector + "." + className + "::before {\n  content: '" + this.content + "';\n  position: fixed;\n  top: 0;\n  left: 0;\n  z-index: 2000;\n  background-color: #0076ff;\n  height: 3px;\n  opacity: " + this.opacity + ";\n  width: " + this.value + "%;\n  transition: width " + this.speed + "ms ease-out, opacity " + (this.speed / 2) + "ms ease-in;\n  transform: translate3d(0,0,0);\n}";
+    return "" + this.elementSelector + "." + className + "::before {\n  content: '" + this.content + "';\n  position: absolute;\n  top: 0;\n  left: 0;\n  z-index: 2000;\n  background-color: #0076ff;\n  height: 3px;\n  opacity: " + this.opacity + ";\n  width: " + this.value + "%;\n  transition: width " + this.speed + "ms ease-out, opacity " + (this.speed / 2) + "ms ease-in;\n  transform: translate3d(0,0,0);\n}";
   };
 
   return ProgressBar;


### PR DESCRIPTION
移动 html5 中慎用 fixed 属性。在 testerhome 已经上线很久，工作正常。