### PR TITLE
增加 oauth 的跨域请求

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -57,6 +57,7 @@ module RubyChina
       allow do
         origins '*'
         resource '/api/*', headers: :any, methods: [:get, :post, :put, :delete, :destroy]
+        resource '/oauth/*', headers: :any, methods: [:get, :post, :put, :delete, :destroy]
       end
     end
 


### PR DESCRIPTION
可以让第三方通过 grant_type=password 方式在前端直接 post form 表单到 `https://ruby-china.org/oauth/token` 获取到合适的 token 并且不需要一个中间服务器来处理这个 proxy

如果需要再严苛一点的路由: 

```ruby
    config.middleware.use Rack::Cors do
      allow do
        origins '*'
        resource '/api/*', headers: :any, methods: [:get, :post, :put, :delete, :destroy]
        resource '/oauth/token', headers: :any, methods: [:post]
      end
    end
```