### PR TITLE
Add dividing line between best articles

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -506,6 +506,11 @@ a.followed {
     a.active { color: #333; border-bottom: 1px dotted #ccc; text-decoration: none; }
     a.popular.active { color: $red; border-bottom-color: $red;}
   }
+  .topics-group:first-child {
+    @media (max-width: 991px) {
+      .topic:last-child { border-bottom: 1px solid #F0F0F0; }
+    }
+  }
   .topic {
     min-height: 68px;
     border-bottom: 1px solid #F0F0F0;

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -49,13 +49,13 @@
     <%
       odd_topics, even_topics = @excellent_topics.partition.each_with_index { |t, i| i.odd?  }
     %>
-    <div class="col-md-6">
+    <div class="col-md-6 topics-group">
       <% cache([odd_topics, "odd"]) do %>
         <%= render partial: "topics/topic", collection: odd_topics, locals: { suggest: false } %>
       <% end %>
     </div>
 
-    <div class="col-md-6">
+    <div class="col-md-6 topics-group">
       <% cache([even_topics, "even"]) do %>
         <%= render partial: "topics/topic", collection: even_topics, locals: { suggest: false } %>
       <% end %>


### PR DESCRIPTION
修复小屏幕尺寸下的响应式细节，问题如：
![qq20150616-1 2x](https://cloud.githubusercontent.com/assets/2900644/8175731/51bb1e86-1421-11e5-8a2a-fe582321eaf7.png)

然后重现：
![screen shot 2015-06-16 at 11 55 26 am](https://cloud.githubusercontent.com/assets/2900644/8175736/5f96e77e-1421-11e5-8871-36e064319ecb.png)

修复后结果：
![screen shot 2015-06-16 at 12 09 58 pm](https://cloud.githubusercontent.com/assets/2900644/8175737/6adf1d90-1421-11e5-972b-c16a2413febf.png)
大屏幕下不影响正常样式：
![screen shot 2015-06-16 at 12 10 48 pm](https://cloud.githubusercontent.com/assets/2900644/8175741/7bd2b256-1421-11e5-8127-ac532f003373.png)

