### PR TITLE
Support tab in the text editor

### DIFF
--- a/app/assets/javascripts/jquery.hotkeys.js
+++ b/app/assets/javascripts/jquery.hotkeys.js
@@ -4,7 +4,8 @@
  * Dual licensed under the MIT or GPL Version 2 licenses.
  *
  * Based upon the plugin by Tzury Bar Yochay:
- * http://github.com/tzuryby/hotkeys
+ * http://github.com/tzuryby/hotkeys (This Location Is Deprecated)
+ * https://github.com/tzuryby/jquery.hotkeys
  *
  * Original idea by:
  * Binny V A, http://www.openjs.com/scripts/events/keyboard_shortcuts/

--- a/app/assets/javascripts/topics.coffee
+++ b/app/assets/javascripts/topics.coffee
@@ -232,6 +232,16 @@ window.TopicView = Backbone.View.extend
       $("form#new_reply").submit()
     return false
 
+  # 往话题编辑器里面的光标前插入两个空白字符
+  insertSpaces : (e) ->
+    target = e.target
+    start = target.selectionStart
+    end = target.selectionEnd
+    $target = $(target)
+    $target.val($target.val().substring(0, start) + "  " + $target.val().substring(end));
+    target.selectionStart = target.selectionEnd = start + 2
+    return false
+
   # 往话题编辑器里面插入代码模版
   appendCodesFromHint : (e) ->
     link = $(e.currentTarget)
@@ -258,6 +268,11 @@ window.TopicView = Backbone.View.extend
     $("textarea").unbind "keydown.mr"
     $("textarea").bind "keydown.mr","Meta+return",(el) =>
       return @submitTextArea(el)
+
+    # 绑定文本框 tab 按键事件
+    $("textarea").unbind "keydown"
+    $("textarea").bind "keydown","tab",(el) =>
+      return @insertSpaces(el)
 
     $("textarea").autogrow()
 


### PR DESCRIPTION
增加文本编辑器中 tab 按键事件的处理，自动插入两个空白字符
![reply](https://cloud.githubusercontent.com/assets/2900644/8392179/ab956b0a-1d13-11e5-8b12-5f4edadbfa86.gif)

加入 tab 事件处理的原因：一个是更符合文本编辑器的使用习惯，另一个是避免还没编辑完的内容因为 tab 默认将输入焦点跳动到了提交按钮，此时不小心按下回车会导致内容被提交。