### PR TITLE
修正 ajax 快速回复后的位置 bug

### DIFF
--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -11,6 +11,9 @@ class RepliesController < ApplicationController
 
     if @reply.save
       current_user.read_topic(@topic)
+      @last_floor = @topic.replies.unscoped.without_body.count
+      @last_page_number = ((@topic.replies.count).to_f / Reply.per_page).ceil
+      @last_page_url_with_floor = topic_path(@topic) + "?page=#{@last_page_number}#reply#{@last_floor.to_s}"
       @msg = t('topics.reply_success')
     else
       @msg = @reply.errors.full_messages.join('<br />')

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -101,7 +101,9 @@ class TopicsController < ApplicationController
 
     set_seo_meta "#{@topic.title} &raquo; #{t("menu.topics")}"
 
-    fresh_when(etag: [@topic, @has_followed, @has_favorited, @replies, @node, @show_raw])
+    @last_floor = ((@page -1) * Reply.per_page) + @replies.count
+
+    fresh_when(etag: [@topic, @has_followed, @has_favorited, @replies, @node, @show_raw, @last_floor])
   end
   
   def check_current_user_liked_replies

--- a/app/views/replies/create.js.erb
+++ b/app/views/replies/create.js.erb
@@ -4,13 +4,24 @@
     Turbolinks.visit(location.href);
   }
   else {
-    var current_floor = parseInt($("#replies").data("last-floor")) + 1;
-    $("#replies .items").append('<%= j(render("reply", reply: @reply, reply_counter: @topic.replies_count - 1, display_edit: true)) %>')
-      .find(".total b").text('<%= @topic.replies_count %>');
-    $("#replies .items .reply:last .reply-floor").text(current_floor + " 楼");
-    $("#replies").data("last-floor", current_floor);
-    $("#replies .reply a.edit:last").css("display","inline-block");
-    _topicView.replyCallback(1,'<%= j(@msg) %>');
+    var client_last_floor = parseInt($("#replies").data("last-floor"));
+    var current_floor = client_last_floor + 1;
+    var remote_last_floor = <%= @last_floor %>;
+    var client_current_page_number = parseInt($("#replies").data("current-page"));
+    var remote_last_page_number = <%= @last_page_number %>;
+
+    if(remote_last_floor > current_floor || remote_last_page_number > client_current_page_number){
+      var url = '<%= @last_page_url_with_floor %>';
+      Turbolinks.visit(url);
+    }
+    else{
+      $("#replies .items").append('<%= j(render("reply", reply: @reply, reply_counter: @topic.replies_count - 1, display_edit: true)) %>')
+        .find(".total b").text('<%= @topic.replies_count %>');
+      $("#replies .items .reply:last .reply-floor").text(current_floor + " 楼");
+      $("#replies").data("last-floor", current_floor);
+      $("#replies .reply a.edit:last").css("display","inline-block");
+      _topicView.replyCallback(1,'<%= j(@msg) %>');
+    }
   }
 <% else %>
   _topicView.replyCallback(0,'<%= j(@msg) %>');

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -49,7 +49,7 @@
       <%= t("topics.no_replies") %>
     </div>
     <% else %>
-    <div id="replies" class="panel panel-default" data-last-floor="<%= @replies.count %>">
+    <div id="replies" class="panel panel-default" data-last-floor="<%= @last_floor %>" data-current-page="<%= @page %>">
       <div class="total panel-heading">
         共收到 <b><%= @topic.replies_count %></b> 条回复
       </div>


### PR DESCRIPTION
当前帖子详情页面每页显示50条回复

情况1，当前已有 50 条回复显示，查看帖子过程中无其他人回复，此时快速回复后会显示51楼；目标：快速回复后应该跳到第二页
情况2，打开页面查看帖子过程中其他人已经回复，甚至已经有了好几页回复，此时快速回复后会仍然挂在当前页面底部，该回帖楼层显示错误；目标：快速回复后跳转到最后一页，并显示正确的楼层。