### PR TITLE
替换标题里面的全部中文中括号和括号到英文, sub -> gsub

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -97,7 +97,7 @@ class Topic
   before_save :auto_correct_title
   def auto_correct_title
     CORRECT_CHARS.each do |chars|
-      self.title.sub!(chars[0], chars[1])
+      self.title.gsub!(chars[0], chars[1])
     end
     self.title.auto_space!
   end


### PR DESCRIPTION
另外直接在这里写 auto_correct_title 是不是不大好? 我去翻了下 auto-space gem, 觉得可以把自动替换这部分加入到 auto-correct 中, 我在你的另一项目 auto-correct 中 pull request 了一点想法, 目前 auto-space 功能略单一, 把功能相近的自动替换一起整合进 auto-correct 中会不会好一些?