### PR TITLE
fix markdown h3 contain link bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ solr/data/
 solr/pids/
 tags
 chromedriver.log
+.idea/

--- a/lib/markdown.rb
+++ b/lib/markdown.rb
@@ -56,7 +56,8 @@ module Redcarpet
     class HTMLwithTopic < HTMLwithSyntaxHighlight
       def header(text, header_level)
         l = header_level <= 2 ? 2 : header_level
-        %(<h#{l} id="#{text}">#{text}</h#{l}>)
+        raw_text = Nokogiri::HTML(text).xpath('//text()')
+        %(<h#{l} id="#{raw_text}">#{text}</h#{l}>)
       end
     end
   end

--- a/spec/lib/markdown_spec.rb
+++ b/spec/lib/markdown_spec.rb
@@ -12,6 +12,15 @@ describe 'markdown' do
     let!(:doc) { Nokogiri::HTML.fragment(MarkdownTopicConverter.format(raw)) }
     subject { doc }
 
+    describe 'inline link in heading' do
+      subject { super().inner_html }
+
+      context 'h3 with inline link' do
+        let(:raw) { "### [rails_panel](https://github.com/dejan/rails_panel)" }
+        it { is_expected.to eq(%(<h3 id="rails_panel"><a href="https://github.com/dejan/rails_panel" target="_blank">rails_panel</a></h3>))}
+      end
+    end
+
     describe 'heading' do
       subject { super().inner_html }
 


### PR DESCRIPTION
@huacnlee @lgn21st @chloerei 

修正markdown中header标题中，包含链接时的，convert的不合适，