### PR TITLE
修正 wiki 回复后仍显示暂无回复的 BUG

### DIFF
--- a/app/views/comments/create.js.erb
+++ b/app/views/comments/create.js.erb
@@ -5,6 +5,7 @@ comments_form = $("#<%= @comment.commentable_type %>_<%= @comment.commentable_id
 comment_line = '<%= j(render("comment", item: @comment)) %>';
 comments_box.append(comment_line);
 $(comment_line).fadeOut("fast");
+comments_box.find('.no-result').remove();
 $("abbr.timeago").timeago();
 $("textarea",comments_form).val("").focus();
 <% else %>


### PR DESCRIPTION
现状：如果一篇 wiki 没有回复，当第一条回复提交并显示该回复后，界面上的 【暂无回复】字样并未消失。
预期：如果一篇 wiki 没有回复，当第一条回复提交并显示该回复后，界面上的 【暂无回复】字样应该自动消失