### PR TITLE
upgrade FactoryGirl

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -118,7 +118,7 @@ group :development, :test do
 
   gem 'rubocop'
   gem 'rspec-rails', '~> 3.1'
-  gem 'factory_girl_rails', '1.4.0'
+  gem 'factory_girl_rails', '~> 4.5.0'
   gem 'database_cleaner'
   gem 'capybara', '~> 2.3.0'
   gem 'api_taster', '0.6.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,10 +152,10 @@ GEM
       actionmailer (>= 3.0.4)
       activesupport (>= 3.0.4)
     execjs (2.4.0)
-    factory_girl (2.3.2)
-      activesupport
-    factory_girl_rails (1.4.0)
-      factory_girl (~> 2.3.0)
+    factory_girl (4.5.0)
+      activesupport (>= 3.0.0)
+    factory_girl_rails (4.5.0)
+      factory_girl (~> 4.5.0)
       railties (>= 3.0.0)
     faraday (0.9.0)
       multipart-post (>= 1.2, < 3)
@@ -453,7 +453,7 @@ DEPENDENCIES
   doorkeeper
   doorkeeper-i18n!
   exception_notification
-  factory_girl_rails (= 1.4.0)
+  factory_girl_rails (~> 4.5.0)
   grape (= 0.7.0)
   grape-active_model_serializers
   hiredis (~> 0.6.0)

--- a/spec/api/likes_spec.rb
+++ b/spec/api/likes_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 describe 'API V3', 'likes', type: :request do
-  let!(:reply) { Factory(:reply) }
-  let!(:topic) { Factory(:topic) }
+  let!(:reply) { create(:reply) }
+  let!(:topic) { create(:topic) }
 
   describe 'POST /api/v3/likes.json' do
     it 'require login' do

--- a/spec/api/nodes_spec.rb
+++ b/spec/api/nodes_spec.rb
@@ -5,7 +5,7 @@ describe 'API V3', 'nodes', type: :request do
   let(:json) { JSON.parse(response.body) }
   describe 'GET /api/nodes.json' do
     before do
-      %w(fun ruby nodes).each_with_index { |n, i| Factory(:node, name: n, id: i + 1) }
+      %w(fun ruby nodes).each_with_index { |n, i| create(:node, name: n, id: i + 1) }
     end
 
     it 'should return the list of nodes' do

--- a/spec/api/notifications_spec.rb
+++ b/spec/api/notifications_spec.rb
@@ -14,9 +14,9 @@ describe 'API V3', 'notifications', type: :request do
     end
 
     it 'should get notification for a mention in a reply' do
-      topic = Factory :topic, user: current_user
-      reply = Factory :reply, topic: topic, user: current_user, body: 'Test to mention user'
-      Factory :notification_mention, user: current_user, mentionable: reply
+      topic = create :topic, user: current_user
+      reply = create :reply, topic: topic, user: current_user, body: 'Test to mention user'
+      create :notification_mention, user: current_user, mentionable: reply
       login_user!
       get '/api/v3/notifications.json'
       expect(response.status).to eq(200)
@@ -29,9 +29,9 @@ describe 'API V3', 'notifications', type: :request do
 
     it 'should get notification for a reply' do
       login_user!
-      topic = Factory :topic, user: current_user
-      reply = Factory :reply, topic: topic, user: current_user, body: 'Test to reply user'
-      Factory :notification_topic_reply, user: current_user, reply: reply
+      topic = create :topic, user: current_user
+      reply = create :reply, topic: topic, user: current_user, body: 'Test to reply user'
+      create :notification_topic_reply, user: current_user, reply: reply
       get '/api/v3/notifications.json'
       expect(response.status).to eq(200)
       json = JSON.parse(response.body)
@@ -43,9 +43,9 @@ describe 'API V3', 'notifications', type: :request do
 
     it 'should get notification for a mention in a topic' do
       login_user!
-      node = Factory :node
-      topic = Factory :topic, user: current_user, node: node, title: 'Test to mention user in a topic'
-      Factory :notification_mention, user: current_user, mentionable: topic
+      node = create :node
+      topic = create :topic, user: current_user, node: node, title: 'Test to mention user in a topic'
+      create :notification_mention, user: current_user, mentionable: topic
       get '/api/v3/notifications.json'
       expect(response.status).to eq(200)
       json = JSON.parse(response.body)
@@ -58,9 +58,9 @@ describe 'API V3', 'notifications', type: :request do
 
     it 'should return a list of notifications of the current user' do
       login_user!
-      topic = Factory :topic, user: current_user
-      replies = (0...10).map { |i| Factory :reply, topic: topic, user: current_user, body: "Test to mention user #{i}" }
-      (0...10).map { |i| Factory :notification_mention, user: current_user, mentionable: replies[i] }
+      topic = create :topic, user: current_user
+      replies = (0...10).map { |i| create :reply, topic: topic, user: current_user, body: "Test to mention user #{i}" }
+      (0...10).map { |i| create :notification_mention, user: current_user, mentionable: replies[i] }
 
       get '/api/v3/notifications.json'
       expect(response.status).to eq(200)
@@ -90,9 +90,9 @@ describe 'API V3', 'notifications', type: :request do
 
     it 'should work' do
       login_user!
-      topic = Factory :topic, user: current_user
-      replies = (0...10).map { |i| Factory :reply, topic: topic, user: current_user, body: "Test to mention user #{i}" }
-      (0...10).map { |i| Factory :notification_mention, user: current_user, mentionable: replies[i] }
+      topic = create :topic, user: current_user
+      replies = (0...10).map { |i| create :reply, topic: topic, user: current_user, body: "Test to mention user #{i}" }
+      (0...10).map { |i| create :notification_mention, user: current_user, mentionable: replies[i] }
       post '/api/v3/notifications/read.json', ids: current_user.notifications.pluck(:id)
       expect(response.status).to eq 201
       current_user.notifications.each do |item|
@@ -109,9 +109,9 @@ describe 'API V3', 'notifications', type: :request do
 
     it 'should delete all notifications of current user' do
       login_user!
-      topic = Factory :topic, user: current_user
-      replies = (0...10).map { |i| Factory :reply, topic: topic, user: current_user, body: "Test to mention user #{i}" }
-      (0...10).map { |i| Factory :notification_mention, user: current_user, mentionable: replies[i] }
+      topic = create :topic, user: current_user
+      replies = (0...10).map { |i| create :reply, topic: topic, user: current_user, body: "Test to mention user #{i}" }
+      (0...10).map { |i| create :notification_mention, user: current_user, mentionable: replies[i] }
 
       get '/api/v3/notifications.json'
       expect(response.status).to eq(200)
@@ -135,9 +135,9 @@ describe 'API V3', 'notifications', type: :request do
 
     it 'should delete the specified notification of current user' do
       login_user!
-      topic = Factory :topic, user: current_user
-      replies = (0...10).map { |i| Factory :reply, topic: topic, user: current_user, body: "Test to mention user #{i}" }
-      mentions = (0...10).map { |i| Factory :notification_mention, user: current_user, mentionable: replies[i] }
+      topic = create :topic, user: current_user
+      replies = (0...10).map { |i| create :reply, topic: topic, user: current_user, body: "Test to mention user #{i}" }
+      mentions = (0...10).map { |i| create :notification_mention, user: current_user, mentionable: replies[i] }
 
       get '/api/v3/notifications.json'
       expect(response.status).to eq(200)

--- a/spec/api/replies_spec.rb
+++ b/spec/api/replies_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe 'API V3', 'replies', type: :request do
-  let!(:reply) { Factory(:reply, user: current_user) }
+  let!(:reply) { create(:reply, user: current_user) }
 
   describe 'GET /api/v3/replies/:id.json' do
     it 'should be ok' do
@@ -16,7 +16,7 @@ describe 'API V3', 'replies', type: :request do
     end
 
     it 'should return right abilities when owner visit' do
-      r = Factory(:reply, user: current_user)
+      r = create(:reply, user: current_user)
       login_user!
       get "/api/v3/replies/#{r.id}.json"
       expect(response.status).to eq(200)
@@ -40,7 +40,7 @@ describe 'API V3', 'replies', type: :request do
     end
 
     it 'require owner' do
-      r = Factory(:reply)
+      r = create(:reply)
       login_user!
       post "/api/v3/replies/#{r.id}.json", body: 'bar dar'
       expect(response.status).to eq(403)
@@ -57,7 +57,7 @@ describe 'API V3', 'replies', type: :request do
 
     it 'should work by admin' do
       login_admin!
-      r = Factory(:reply)
+      r = create(:reply)
       post "/api/v3/replies/#{r.id}.json", body: 'bar dar'
       expect(response.status).to eq(201)
     end
@@ -70,7 +70,7 @@ describe 'API V3', 'replies', type: :request do
     end
 
     it 'require owner' do
-      r = Factory(:reply)
+      r = create(:reply)
       login_user!
       delete "/api/v3/replies/#{r.id}.json"
       expect(response.status).to eq(403)
@@ -86,7 +86,7 @@ describe 'API V3', 'replies', type: :request do
 
     it 'should work by admin' do
       login_admin!
-      r = Factory(:reply)
+      r = create(:reply)
       delete "/api/v3/replies/#{r.id}.json"
       expect(response.status).to eq(200)
       r.reload

--- a/spec/api/topics_spec.rb
+++ b/spec/api/topics_spec.rb
@@ -8,13 +8,13 @@ describe 'API V3', 'topics', type: :request do
     end
 
     it 'should be ok for all types' do
-      Factory(:topic, title: 'This is a normal topic', replies_count: 1)
-      Factory(:topic, title: 'This is an excellent topic', excellent: 1, replies_count: 1)
-      Factory(:topic, title: 'This is a no_reply topic', replies_count: 0)
-      Factory(:topic, title: 'This is a popular topic', replies_count: 1, likes_count: 10)
+      create(:topic, title: 'This is a normal topic', replies_count: 1)
+      create(:topic, title: 'This is an excellent topic', excellent: 1, replies_count: 1)
+      create(:topic, title: 'This is a no_reply topic', replies_count: 0)
+      create(:topic, title: 'This is a popular topic', replies_count: 1, likes_count: 10)
 
-      node = Factory(:node, name: 'No Point')
-      Factory(:topic, title: 'This is a No Point topic', node: node)
+      node = create(:node, name: 'No Point')
+      create(:topic, title: 'This is a No Point topic', node: node)
       SiteConfig.node_ids_hide_in_topics_index = node.id.to_s
 
       get '/api/v3/topics.json'
@@ -67,11 +67,11 @@ describe 'API V3', 'topics', type: :request do
 
     describe 'with logined user' do
       it 'should hide user blocked nodes/users' do
-        user = Factory(:user)
-        node = Factory(:node)
-        Factory(:topic, user: user)
-        Factory(:topic, node: node)
-        t3 = Factory(:topic)
+        user = create(:user)
+        node = create(:node)
+        create(:topic, user: user)
+        create(:topic, node: node)
+        t3 = create(:topic)
         current_user.block_user(user.id)
         current_user.block_node(node.id)
         login_user!
@@ -83,16 +83,16 @@ describe 'API V3', 'topics', type: :request do
   end
 
   describe 'GET /api/v3/topics.json with node_id' do
-    let(:node) { Factory(:node) }
-    let(:node1) { Factory(:node) }
+    let(:node) { create(:node) }
+    let(:node1) { create(:node) }
 
-    let(:t1) { Factory(:topic, node_id: node.id, title: 'This is a normal topic', replies_count: 1) }
-    let(:t2) { Factory(:topic, node_id: node.id, title: 'This is an excellent topic', excellent: 1, replies_count: 1) }
-    let(:t3) { Factory(:topic, node_id: node.id, title: 'This is a no_reply topic', replies_count: 0) }
-    let(:t4) { Factory(:topic, node_id: node.id, title: 'This is a popular topic', replies_count: 1, likes_count: 10) }
+    let(:t1) { create(:topic, node_id: node.id, title: 'This is a normal topic', replies_count: 1) }
+    let(:t2) { create(:topic, node_id: node.id, title: 'This is an excellent topic', excellent: 1, replies_count: 1) }
+    let(:t3) { create(:topic, node_id: node.id, title: 'This is a no_reply topic', replies_count: 0) }
+    let(:t4) { create(:topic, node_id: node.id, title: 'This is a popular topic', replies_count: 1, likes_count: 10) }
 
     it 'should return a list of topics that belong to the specified node' do
-      other_topics = [Factory(:topic, node_id: node1.id), Factory(:topic, node_id: node1.id)]
+      other_topics = [create(:topic, node_id: node1.id), create(:topic, node_id: node1.id)]
       topics = [t1, t2, t3, t4]
 
       get '/api/v3/topics.json', node_id: -1
@@ -169,7 +169,7 @@ describe 'API V3', 'topics', type: :request do
 
     it 'should work' do
       login_user!
-      node_id = Factory(:node)._id
+      node_id = create(:node)._id
       post '/api/v3/topics.json', title: 'api create topic', body: 'here we go', node_id: node_id
       expect(response.status).to eq(201)
       expect(json['topic']['body_html']).to eq '<p>here we go</p>'
@@ -182,7 +182,7 @@ describe 'API V3', 'topics', type: :request do
   end
 
   describe 'POST /api/v3/topics/:id.json' do
-    let!(:topic) { Factory(:topic) }
+    let!(:topic) { create(:topic) }
 
     it 'should require user' do
       post "/api/v3/topics/#{topic.id}.json", title: 'api create topic', body: 'here we go', node_id: 1
@@ -196,7 +196,7 @@ describe 'API V3', 'topics', type: :request do
     end
 
     it 'should update with admin user' do
-      new_node = Factory(:node)
+      new_node = create(:node)
       login_admin!
       post "/api/v3/topics/#{topic.id}.json", title: 'api create topic', body: 'here we go', node_id: new_node.id
       expect(response.status).to eq 201
@@ -205,11 +205,11 @@ describe 'API V3', 'topics', type: :request do
     end
 
     context 'with user' do
-      let!(:topic) { Factory(:topic, user: current_user) }
+      let!(:topic) { create(:topic, user: current_user) }
 
       it 'should work' do
         login_user!
-        node_id = Factory(:node)._id
+        node_id = create(:node)._id
         post "/api/v3/topics/#{topic.id}.json", title: 'api create topic', body: 'here we go', node_id: node_id
         expect(response.status).to eq(201)
         expect(json['topic']['body_html']).to eq '<p>here we go</p>'
@@ -224,7 +224,7 @@ describe 'API V3', 'topics', type: :request do
       it 'should node update node_id when topic is lock_node' do
         topic.update_attribute(:lock_node, true)
         login_user!
-        node_id = Factory(:node)._id
+        node_id = create(:node)._id
         post "/api/v3/topics/#{topic.id}.json", title: 'api create topic', body: 'here we go', node_id: node_id
         topic.reload
         expect(topic.node_id).not_to eq node_id
@@ -234,7 +234,7 @@ describe 'API V3', 'topics', type: :request do
 
   describe 'GET /api/v3/topics/:id.json' do
     it 'should get topic detail with list of replies' do
-      t = Factory(:topic, title: 'i want to know')
+      t = create(:topic, title: 'i want to know')
       old_hits = t.hits.to_i
       get "/api/v3/topics/#{t.id}.json"
       expect(response.status).to eq(200)
@@ -251,7 +251,7 @@ describe 'API V3', 'topics', type: :request do
     end
 
     it 'should return right abilities when owner visit' do
-      t = Factory(:topic, user: current_user)
+      t = create(:topic, user: current_user)
       login_user!
       get "/api/v3/topics/#{t.id}.json"
       expect(response.status).to eq(200)
@@ -260,7 +260,7 @@ describe 'API V3', 'topics', type: :request do
     end
 
     it 'should return right abilities when admin visit' do
-      t = Factory(:topic)
+      t = create(:topic)
       login_admin!
       get "/api/v3/topics/#{t.id}.json"
       expect(response.status).to eq(200)
@@ -277,9 +277,9 @@ describe 'API V3', 'topics', type: :request do
   describe 'GET /api/v3/topic/:id/replies.json' do
     it 'should work' do
       login_user!
-      t = Factory(:topic, title: 'i want to know')
-      r1 = Factory(:reply, topic_id: t.id, body: 'let me tell', user: current_user)
-      r2 = Factory(:reply, topic_id: t.id, body: 'let me tell again', deleted_at: Time.now)
+      t = create(:topic, title: 'i want to know')
+      r1 = create(:reply, topic_id: t.id, body: 'let me tell', user: current_user)
+      r2 = create(:reply, topic_id: t.id, body: 'let me tell again', deleted_at: Time.now)
       get "/api/v3/topics/#{t.id}/replies.json"
       expect(response.status).to eq(200)
       expect(json['replies'].size).to eq 2
@@ -297,9 +297,9 @@ describe 'API V3', 'topics', type: :request do
 
     it 'should return right abilities when admin visit' do
       login_admin!
-      t = Factory(:topic, title: 'i want to know')
-      Factory(:reply, topic_id: t.id, body: 'let me tell')
-      Factory(:reply, topic_id: t.id, body: 'let me tell again', deleted_at: Time.now)
+      t = create(:topic, title: 'i want to know')
+      create(:reply, topic_id: t.id, body: 'let me tell')
+      create(:reply, topic_id: t.id, body: 'let me tell again', deleted_at: Time.now)
       get "/api/v3/topics/#{t.id}/replies.json"
       expect(response.status).to eq(200)
       expect(json['replies'][0]['abilities']['update']).to eq true
@@ -312,7 +312,7 @@ describe 'API V3', 'topics', type: :request do
   describe 'POST /api/v3/topics/:id/replies.json' do
     it 'should post a new reply' do
       login_user!
-      t = Factory(:topic, title: 'new topic 1')
+      t = create(:topic, title: 'new topic 1')
       post "/api/v3/topics/#{t.id}/replies.json", body: 'new reply body'
       expect(response.status).to eq(201)
       expect(t.reload.replies.first.body).to eq('new reply body')
@@ -322,7 +322,7 @@ describe 'API V3', 'topics', type: :request do
   describe 'POST /api/v3/topics/:id/follow.json' do
     it 'should follow a topic' do
       login_user!
-      t = Factory(:topic, title: 'new topic 2')
+      t = create(:topic, title: 'new topic 2')
       post "/api/v3/topics/#{t.id}/follow.json"
       expect(response.status).to eq(201)
       expect(t.reload.follower_ids).to include(current_user.id)
@@ -332,7 +332,7 @@ describe 'API V3', 'topics', type: :request do
   describe 'POST /api/v3/topics/:id/unfollow.json' do
     it 'should unfollow a topic' do
       login_user!
-      t = Factory(:topic, title: 'new topic 2')
+      t = create(:topic, title: 'new topic 2')
       post "/api/v3/topics/#{t.id}/unfollow.json"
       expect(response.status).to eq(201)
       expect(t.reload.follower_ids).not_to include(current_user.id)
@@ -342,7 +342,7 @@ describe 'API V3', 'topics', type: :request do
   describe 'POST /api/v3/topics/:id/favorite.json' do
     it 'should favorite a topic' do
       login_user!
-      t = Factory(:topic, title: 'new topic 3')
+      t = create(:topic, title: 'new topic 3')
       post "/api/v3/topics/#{t.id}/favorite.json"
       expect(response.status).to eq(201)
       expect(current_user.reload.favorite_topic_ids).to include(t.id)
@@ -352,7 +352,7 @@ describe 'API V3', 'topics', type: :request do
   describe 'POST /api/v3/topics/:id/unfavorite.json' do
     it 'should unfavorite a topic' do
       login_user!
-      t = Factory(:topic, title: 'new topic 3')
+      t = create(:topic, title: 'new topic 3')
       post "/api/v3/topics/#{t.id}/unfavorite.json"
       expect(response.status).to eq(201)
       expect(current_user.reload.favorite_topic_ids).not_to include(t.id)

--- a/spec/api/users_spec.rb
+++ b/spec/api/users_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe 'API V3', 'users', type: :request do
   describe 'GET /api/v3/users.json' do
     before do
-      FactoryGirl.create_list(:user, 10)
+      create_list(:user, 10)
     end
 
     it 'should work' do
@@ -22,7 +22,7 @@ describe 'API V3', 'users', type: :request do
 
   describe 'GET /api/v3/users/:login.json' do
     it 'should get user details with list of topics' do
-      user = Factory(:user, name: 'test user', login: 'test_user', email: 'foobar@gmail.com', email_public: true)
+      user = create(:user, name: 'test user', login: 'test_user', email: 'foobar@gmail.com', email_public: true)
       get '/api/v3/users/test_user.json'
       expect(response.status).to eq 200
       fields = %w(id name login email avatar_url location company twitter github website bio tagline)
@@ -33,7 +33,7 @@ describe 'API V3', 'users', type: :request do
     end
 
     it 'should hidden email when email_public is false' do
-      Factory(:user, name: 'test user',
+      create(:user, name: 'test user',
                      login: 'test_user',
                      email: 'foobar@gmail.com',
                      email_public: false)
@@ -51,11 +51,11 @@ describe 'API V3', 'users', type: :request do
   end
 
   describe 'GET /api/v3/users/:login/topics.json' do
-    let(:user) { Factory(:user) }
+    let(:user) { create(:user) }
 
     describe 'recent order' do
       it 'should work' do
-        @topics = FactoryGirl.create_list(:topic, 3, user: user)
+        @topics = create_list(:topic, 3, user: user)
         get "/api/v3/users/#{user.login}/topics.json", offset: 0, limit: 2
         expect(response.status).to eq 200
         expect(json['topics'].size).to eq 2
@@ -69,8 +69,8 @@ describe 'API V3', 'users', type: :request do
 
     describe 'hot order' do
       it 'should work' do
-        @hot_topic = Factory.create(:topic, user: user, likes_count: 4)
-        @topics = FactoryGirl.create_list(:topic, 3, user: user)
+        @hot_topic = create(:topic, user: user, likes_count: 4)
+        @topics = create_list(:topic, 3, user: user)
 
         get "/api/v3/users/#{user.login}/topics.json", order: 'likes', offset: 0, limit: 3
         expect(response.status).to eq 200
@@ -81,8 +81,8 @@ describe 'API V3', 'users', type: :request do
 
     describe 'hot order' do
       it 'should work' do
-        @hot_topic = Factory.create(:topic, user: user, replies_count: 4)
-        @topics = FactoryGirl.create_list(:topic, 3, user: user)
+        @hot_topic = create(:topic, user: user, replies_count: 4)
+        @topics = create_list(:topic, 3, user: user)
 
         get "/api/v3/users/#{user.login}/topics.json", order: 'replies', offset: 0, limit: 3
         expect(response.status).to eq 200
@@ -93,10 +93,10 @@ describe 'API V3', 'users', type: :request do
   end
 
   describe 'GET /api/v3/users/:login/favorites.json' do
-    let(:user) { Factory(:user) }
+    let(:user) { create(:user) }
 
     it 'should work' do
-      @topics = FactoryGirl.create_list(:topic, 4, user: user)
+      @topics = create_list(:topic, 4, user: user)
       user.favorite_topic(@topics[0].id)
       user.favorite_topic(@topics[1].id)
       user.favorite_topic(@topics[3].id)
@@ -112,10 +112,10 @@ describe 'API V3', 'users', type: :request do
   end
 
   describe 'GET /api/v3/users/:login/followers.json' do
-    let(:user) { Factory(:user) }
+    let(:user) { create(:user) }
 
     it 'should work' do
-      @users = FactoryGirl.create_list(:user, 3)
+      @users = create_list(:user, 3)
       @users.each do |u|
         u.follow_user(user)
       end
@@ -129,7 +129,7 @@ describe 'API V3', 'users', type: :request do
   end
 
   describe 'GET /api/v3/users/:login/blocked.json' do
-    let(:user) { Factory(:user) }
+    let(:user) { create(:user) }
 
     it 'require login' do
       get "/api/v3/users/#{user.login}/blocked.json"
@@ -143,7 +143,7 @@ describe 'API V3', 'users', type: :request do
     end
 
     it 'should work' do
-      @users = FactoryGirl.create_list(:user, 3)
+      @users = create_list(:user, 3)
       login_user!
 
       @users.each do |u|
@@ -159,10 +159,10 @@ describe 'API V3', 'users', type: :request do
   end
 
   describe 'GET /api/v3/users/:login/following.json' do
-    let(:user) { Factory(:user) }
+    let(:user) { create(:user) }
 
     it 'should work' do
-      @users = FactoryGirl.create_list(:user, 3)
+      @users = create_list(:user, 3)
       @users.each do |u|
         user.follow_user(u)
       end
@@ -176,7 +176,7 @@ describe 'API V3', 'users', type: :request do
   end
 
   describe 'POST /api/v3/users/:login/follow.json / unfollow' do
-    let(:user) { Factory(:user) }
+    let(:user) { create(:user) }
 
     it 'should 401 when nologin' do
       post "/api/v3/users/#{user.login}/follow.json"
@@ -207,7 +207,7 @@ describe 'API V3', 'users', type: :request do
   end
 
   describe 'POST /api/v3/users/:login/block.json / unblock.json' do
-    let(:user) { Factory(:user) }
+    let(:user) { create(:user) }
 
     it 'should 401 when nologin' do
       post "/api/v3/users/#{user.login}/block.json"

--- a/spec/controllers/cpanel/comments_controller_spec.rb
+++ b/spec/controllers/cpanel/comments_controller_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
 describe Cpanel::CommentsController, type: :controller do
-  let(:comment) { Factory :comment }
+  let(:comment) { create :comment }
 
   before do
-    sign_in Factory(:admin)
+    sign_in create(:admin)
   end
 
   describe 'GET index' do

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe HomeController, type: :controller do
   describe ':index' do
-    let(:user) { Factory :user }
+    let(:user) { create :user }
     it 'should show register link if user not signed in' do
       get :index
       expect(response).to be_success

--- a/spec/controllers/likes_controller_spec.rb
+++ b/spec/controllers/likes_controller_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 describe LikesController, type: :controller do
-  let(:user) { Factory(:user) }
-  let(:user2) { Factory(:user) }
-  let(:topic) { Factory(:topic) }
+  let(:user) { create(:user) }
+  let(:user2) { create(:user) }
+  let(:topic) { create(:topic) }
 
   before(:each) do
     allow(controller).to receive(:current_user).and_return(user)

--- a/spec/controllers/notes_controller_spec.rb
+++ b/spec/controllers/notes_controller_spec.rb
@@ -9,8 +9,8 @@ describe NotesController, type: :controller do
   end
 
   describe 'authenticated' do
-    let(:user) { Factory :user }
-    let(:note) { Factory :note, user: user }
+    let(:user) { create :user }
+    let(:note) { create :note, user: user }
 
     before(:each) { sign_in user }
 

--- a/spec/controllers/notifications_controller_spec.rb
+++ b/spec/controllers/notifications_controller_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
 describe NotificationsController, type: :controller do
-  let(:user) { Factory :user }
+  let(:user) { create :user }
   describe '#index' do
     it 'should show notifications' do
       sign_in user
-      Factory :notification_mention, user: user, mentionable: Factory(:reply)
-      Factory :notification_topic_reply, user: user
+      create :notification_mention, user: user, mentionable: create(:reply)
+      create :notification_topic_reply, user: user
       get :index
       expect(response).to render_template(:index)
     end
@@ -15,7 +15,7 @@ describe NotificationsController, type: :controller do
   describe '#destroy' do
     it 'should destroy notification' do
       sign_in user
-      notification = Factory :notification_mention, user: user, mentionable: Factory(:reply)
+      notification = create :notification_mention, user: user, mentionable: create(:reply)
 
       expect do
         delete :destroy, id: notification
@@ -26,7 +26,7 @@ describe NotificationsController, type: :controller do
   describe '#clear' do
     it 'should clear all' do
       sign_in user
-      3.times { Factory :notification_mention, user: user, mentionable: Factory(:reply) }
+      3.times { create :notification_mention, user: user, mentionable: create(:reply) }
 
       post :clear
       expect(user.notifications.unread.count).to eq(0)

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 describe PagesController, type: :controller do
-  let(:page) { Factory :page }
-  let(:user) { Factory :wiki_editor }
+  let(:page) { create :page }
+  let(:user) { create :wiki_editor }
 
   describe ':index' do
     it 'should have an index action' do
@@ -66,14 +66,14 @@ describe PagesController, type: :controller do
 
     it 'should create new page if all is well' do
       sign_in user
-      params = Factory.attributes_for(:page)
+      params = attributes_for(:page)
       post :create, page: params
       expect(response).to redirect_to page_path(params[:slug])
     end
 
     it 'should not create new page if title is not present' do
       sign_in user
-      params = Factory.attributes_for(:page)
+      params = attributes_for(:page)
       params[:title] = ''
       post :create, page: params
       expect(response).to render_template(:new)
@@ -88,7 +88,7 @@ describe PagesController, type: :controller do
 
     it 'should update page if all is well' do
       sign_in user
-      params = Factory.attributes_for(:page)
+      params = attributes_for(:page)
       page = Page.create!(params)
       params[:title] = 'shiney new title'
       params[:change_desc] = 'updated title'
@@ -98,7 +98,7 @@ describe PagesController, type: :controller do
 
     it 'should not update page if change_desc is not present' do
       sign_in user
-      params = Factory.attributes_for(:page)
+      params = attributes_for(:page)
       page = Page.create!(params)
       params[:title] = 'shiney new title'
       params[:change_desc] = nil

--- a/spec/controllers/replies_controller_spec.rb
+++ b/spec/controllers/replies_controller_spec.rb
@@ -3,11 +3,11 @@ require 'rails_helper'
 describe RepliesController, type: :controller do
   describe '#create' do
     it 'should create reply and set topic read' do
-      user = Factory :user
-      topic = Factory :topic
+      user = create :user
+      topic = create :topic
       expect(user.topic_read?(topic)).to be_falsey
 
-      Factory :reply, topic: topic
+      create :reply, topic: topic
       sign_in user
       post :create, topic_id: topic.id, reply: { body: 'content' }, format: :js
       expect(response).to be_success
@@ -16,9 +16,9 @@ describe RepliesController, type: :controller do
   end
 
   describe '#update' do
-    let(:topic) { Factory :topic }
-    let(:user) { Factory :user }
-    let(:reply) { Factory :reply, user: user, topic: topic }
+    let(:topic) { create :topic }
+    let(:user) { create :user }
+    let(:reply) { create :reply, user: user, topic: topic }
 
     it "should not change topic's last reply info to previous one" do
       sign_in user
@@ -28,12 +28,12 @@ describe RepliesController, type: :controller do
   end
 
   describe '#destroy' do
-    let(:topic) { Factory :topic }
-    let(:admin) { Factory :admin }
-    let(:user) { Factory :user }
-    let(:user1) { Factory :user }
-    let(:reply) { Factory :reply, user: user, topic: topic }
-    let(:reply1) { Factory :reply, user: user1, topic: topic }
+    let(:topic) { create :topic }
+    let(:admin) { create :admin }
+    let(:user) { create :user }
+    let(:user1) { create :user }
+    let(:reply) { create :reply, user: user, topic: topic }
+    let(:reply1) { create :reply, user: user1, topic: topic }
 
     it 'should require login to destroy reply' do
       delete :destroy, topic_id: topic.id, id: reply.id

--- a/spec/controllers/sites_controller_spec.rb
+++ b/spec/controllers/sites_controller_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 describe SitesController, type: :controller do
-  let(:user) { Factory :user, replies_count: 100 }
-  let(:user1) { Factory :user }
+  let(:user) { create :user, replies_count: 100 }
+  let(:user1) { create :user }
   describe ':index' do
     it 'should have an index action' do
       get :index
@@ -30,9 +30,9 @@ describe SitesController, type: :controller do
   end
 
   describe ':create' do
-    let(:site_node) { Factory :site_node }
+    let(:site_node) { create :site_node }
     it 'should not allow anonymous access' do
-      params = Factory.attributes_for(:site, site_node_id: site_node.id)
+      params = attributes_for(:site, site_node_id: site_node.id)
       post :create, site: params # avoids ActionController::ParameterMissing
       expect(response).not_to be_success
     end
@@ -43,13 +43,13 @@ describe SitesController, type: :controller do
       end
 
       it 'should create new site if all is well' do
-        params = Factory.attributes_for(:site, site_node_id: site_node.id)
+        params = attributes_for(:site, site_node_id: site_node.id)
         post :create, site: params
         expect(response).to redirect_to(sites_path)
       end
 
       it 'should not create new site if url is blank' do
-        params = Factory.attributes_for(:site)
+        params = attributes_for(:site)
         params[:url] = ''
         post :create, site: params
         expect(response).to render_template(:new)

--- a/spec/controllers/topics_controller_spec.rb
+++ b/spec/controllers/topics_controller_spec.rb
@@ -2,10 +2,10 @@ require 'rails_helper'
 
 describe TopicsController, type: :controller do
   render_views
-  let(:topic) { Factory :topic, user: user }
-  let(:user) { Factory :user }
-  let(:newbie) { Factory :newbie }
-  let(:admin) { Factory :admin }
+  let(:topic) { create :topic, user: user }
+  let(:user) { create :user }
+  let(:newbie) { create :newbie }
+  let(:admin) { create :admin }
 
   describe ':index' do
     it 'should have an index action' do
@@ -85,8 +85,8 @@ describe TopicsController, type: :controller do
 
       context "other's topic" do
         it "should not allow edit other's topic" do
-          other_user = Factory :user
-          topic_of_other_user = Factory(:topic, user: other_user)
+          other_user = create :user
+          topic_of_other_user = create(:topic, user: other_user)
           sign_in user
           get :edit, id: topic_of_other_user.id
           expect(response).not_to be_success
@@ -97,9 +97,9 @@ describe TopicsController, type: :controller do
 
   describe '#show' do
     it 'should clear user mention notification when show topic' do
-      user = Factory :user
-      topic = Factory :topic, body: "@#{user.login}"
-      Factory :reply, body: "@#{user.login}", topic: topic
+      user = create :user
+      topic = create :topic, body: "@#{user.login}"
+      create :reply, body: "@#{user.login}", topic: topic
       sign_in user
       expect do
         get :show, id: topic.id
@@ -107,9 +107,9 @@ describe TopicsController, type: :controller do
     end
 
     context 'when the topic has 11 replies, and 10 are shown per page' do
-      let!(:user) { FactoryGirl.build_stubbed(:user) }
-      let!(:topic) { FactoryGirl.create(:topic) }
-      let!(:reply) { FactoryGirl.create_list(:reply, 11, topic: topic) }
+      let!(:user) { build_stubbed(:user) }
+      let!(:topic) { create(:topic) }
+      let!(:reply) { create_list(:reply, 11, topic: topic) }
 
       before { sign_in user }
 
@@ -137,7 +137,7 @@ describe TopicsController, type: :controller do
 
   describe '#unsuggest' do
     context 'suggested topic' do
-      let!(:topic) { FactoryGirl.create(:topic, excellent: 1) }
+      let!(:topic) { create(:topic, excellent: 1) }
 
       it 'should not allow user suggest' do
         sign_in user

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 describe UsersController, type: :controller do
-  let(:user) { Factory :user, location: 'Shanghai' }
-  let(:deleted_user) { Factory :user, state: User::STATE[:deleted] }
+  let(:user) { create :user, location: 'Shanghai' }
+  let(:deleted_user) { create :user, state: User::STATE[:deleted] }
 
   describe 'Visit deleted user' do
     it 'should 404 with deleted user' do
@@ -50,8 +50,8 @@ describe UsersController, type: :controller do
     end
 
     it 'assigns @notes' do
-      note_1 = Factory(:note, publish: true, user: user)
-      Factory(:note, publish: false, user: user)
+      note_1 = create(:note, publish: true, user: user)
+      create(:note, publish: false, user: user)
       get :notes, id: user.login
       expect(assigns(:notes)).to eq([note_1])
     end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -23,8 +23,8 @@ describe ApplicationHelper, type: :helper do
   end
 
   describe 'admin?' do
-    let(:user) { Factory :user }
-    let(:admin) { Factory :admin }
+    let(:user) { create :user }
+    let(:admin) { create :admin }
 
     it 'knows you are not an admin' do
       expect(helper.admin?(user)).to be_falsey
@@ -51,8 +51,8 @@ describe ApplicationHelper, type: :helper do
   end
 
   describe 'wiki_editor?' do
-    let(:non_editor) { Factory :non_wiki_editor }
-    let(:editor) { Factory :wiki_editor }
+    let(:non_editor) { create :non_wiki_editor }
+    let(:editor) { create :wiki_editor }
 
     it 'knows non editor is not wiki editor' do
       expect(helper.wiki_editor?(non_editor)).to be_falsey
@@ -75,8 +75,8 @@ describe ApplicationHelper, type: :helper do
 
   describe 'owner?' do
     require 'ostruct'
-    let(:user) { Factory :user }
-    let(:user2) { Factory :user }
+    let(:user) { create :user }
+    let(:user2) { create :user }
     let(:item) { OpenStruct.new user_id: user.id }
 
     it 'knows who is owner' do

--- a/spec/helpers/likes_helper_spec.rb
+++ b/spec/helpers/likes_helper_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 describe LikesHelper, type: :helper do
   describe 'likeable_tag' do
-    let(:user) { Factory :user }
-    let(:topic) { Factory :topic }
+    let(:user) { create :user }
+    let(:topic) { create :topic }
 
     it 'should run with nil param' do
       allow(helper).to receive(:current_user).and_return(nil)

--- a/spec/helpers/locations_helper_spec.rb
+++ b/spec/helpers/locations_helper_spec.rb
@@ -6,7 +6,7 @@ describe LocationsHelper, type: :helper do
   end
 
   it 'should location_name_tag work with Location instance' do
-    location = Factory(:location)
+    location = create(:location)
     expect(helper.location_name_tag(location)).to eq(link_to(location.name, location_users_path(location.name)))
   end
 end

--- a/spec/helpers/nodes_helper_spec.rb
+++ b/spec/helpers/nodes_helper_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe NodesHelper, type: :helper do
   it 'should render_node_summary' do
-    @node = Factory :node
+    @node = create :node
     expect(helper.render_node_summary(@node)).to eq(%(<p class="summary">#{@node.summary}</p>))
   end
 end

--- a/spec/helpers/topics_helper_spec.rb
+++ b/spec/helpers/topics_helper_spec.rb
@@ -71,7 +71,7 @@ describe TopicsHelper, type: :helper do
     end
 
     it 'should link mentioned user' do
-      user = Factory(:user)
+      user = create(:user)
       expect(helper.markdown("hello @#{user.name} @b @a @#{user.name}")).to eq(
         "<p>hello <a href=\"/#{user.name}\" class=\"at_user\" title=\"@#{user.name}\"><i>@</i>#{user.name}</a> <a href=\"/b\" class=\"at_user\" title=\"@b\"><i>@</i>b</a> <a href=\"/a\" class=\"at_user\" title=\"@a\"><i>@</i>a</a> <a href=\"/#{user.name}\" class=\"at_user\" title=\"@#{user.name}\"><i>@</i>#{user.name}</a></p>"
       )
@@ -149,8 +149,8 @@ describe TopicsHelper, type: :helper do
   end
 
   describe 'topic_favorite_tag' do
-    let(:user) { Factory :user }
-    let(:topic) { Factory :topic }
+    let(:user) { create :user }
+    let(:topic) { create :topic }
 
     it 'should run with nil param' do
       allow(helper).to receive(:current_user).and_return(nil)
@@ -177,8 +177,8 @@ describe TopicsHelper, type: :helper do
   end
 
   describe 'topic_follow_tag' do
-    let(:topic) { Factory :topic }
-    let(:user) { Factory :user }
+    let(:topic) { create :topic }
+    let(:user) { create :user }
 
     it 'should return empty when current_user is nil' do
       allow(helper).to receive(:current_user).and_return(nil)

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -13,7 +13,7 @@ describe UsersHelper, type: :helper do
 
   describe 'user_name_tag' do
     it 'should result right html in normal' do
-      user = Factory(:user)
+      user = create(:user)
       expect(helper.user_name_tag(user)).to eq(link_to(user.login, user_path(user.login), 'data-name' => user.name))
     end
 
@@ -28,7 +28,7 @@ describe UsersHelper, type: :helper do
   end
 
   describe 'user personal website' do
-    let(:user) { Factory(:user, website: 'http://example.com') }
+    let(:user) { create(:user, website: 'http://example.com') }
     subject { helper.render_user_personal_website(user) }
 
     it { is_expected.to eq(link_to(user.website, user.website, target: '_blank', class: 'url', rel: 'nofollow')) }
@@ -41,7 +41,7 @@ describe UsersHelper, type: :helper do
   end
 
   describe '.render_user_level_tag' do
-    let(:user) { Factory(:user) }
+    let(:user) { create(:user) }
     subject { helper.render_user_level_tag(user) }
 
     it 'admin should work' do

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -5,7 +5,7 @@ describe Ability, type: :model do
   subject { ability }
 
   context 'Admin manage all' do
-    let(:admin) { Factory :admin }
+    let(:admin) { create :admin }
     let(:ability) { Ability.new(admin) }
 
     it { is_expected.to be_able_to(:manage, Topic) }
@@ -21,9 +21,9 @@ describe Ability, type: :model do
   end
 
   context 'Wiki Editor manage wiki' do
-    let(:wiki_editor) { Factory :wiki_editor }
+    let(:wiki_editor) { create :wiki_editor }
     let(:ability) { Ability.new(wiki_editor) }
-    let(:page_locked) { Factory :page, locked: true }
+    let(:page_locked) { create :page, locked: true }
     it { is_expected.not_to be_able_to(:destroy, Page) }
     it { is_expected.not_to be_able_to(:suggest, Topic) }
     it { is_expected.not_to be_able_to(:unsuggest, Topic) }
@@ -33,7 +33,7 @@ describe Ability, type: :model do
   end
 
   context 'Site editor users' do
-    let(:site_editor) { Factory :user, replies_count: 100 }
+    let(:site_editor) { create :user, replies_count: 100 }
     let(:ability) { Ability.new(site_editor) }
 
     context 'Site' do
@@ -43,13 +43,13 @@ describe Ability, type: :model do
   end
 
   context 'Normal users' do
-    let(:user) { Factory :user }
-    let(:topic) { Factory :topic, user: user }
-    let(:locked_topic) { Factory :topic, user: user, lock_node: true }
-    let(:reply) { Factory :reply, user: user }
-    let(:note) { Factory :note, user: user }
-    let(:comment) { Factory :comment, user: user }
-    let(:note_publish) { Factory :note, publish: true }
+    let(:user) { create :user }
+    let(:topic) { create :topic, user: user }
+    let(:locked_topic) { create :topic, user: user, lock_node: true }
+    let(:reply) { create :reply, user: user }
+    let(:note) { create :note, user: user }
+    let(:comment) { create :comment, user: user }
+    let(:note_publish) { create :note, publish: true }
 
     let(:ability) { Ability.new(user) }
 
@@ -115,7 +115,7 @@ describe Ability, type: :model do
   end
 
   context 'Newbie users' do
-    let(:newbie) { Factory :newbie }
+    let(:newbie) { create :newbie }
     let(:ability) { Ability.new(newbie) }
     context 'Topic' do
       it { is_expected.not_to be_able_to(:create, Topic) }
@@ -125,7 +125,7 @@ describe Ability, type: :model do
   end
 
   context 'Blocked users' do
-    let(:blocked_user) { Factory :blocked_user }
+    let(:blocked_user) { create :blocked_user }
     let(:ability) { Ability.new(blocked_user) }
 
     context 'Topic' do
@@ -146,7 +146,7 @@ describe Ability, type: :model do
   end
 
   context 'Deleted users' do
-    let(:deleted_user) { Factory :deleted_user }
+    let(:deleted_user) { create :deleted_user }
     let(:ability) { Ability.new(deleted_user) }
     context 'Topic' do
       it { is_expected.not_to be_able_to(:create, Topic) }

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe Location, type: :model do
   before(:each) do
-    @location = Factory(:location, name: 'foo')
+    @location = create(:location, name: 'foo')
   end
 
   it 'should validates_uniqueness_of :name ignore case' do

--- a/spec/models/mongoid/mentionable_spec.rb
+++ b/spec/models/mongoid/mentionable_spec.rb
@@ -11,36 +11,36 @@ end
 
 describe Mongoid::Mentionable, type: :model do
   it 'should extract mentioned user ids' do
-    user = Factory :user
-    doc = TestDocument.create body: "@#{user.login}", user: Factory(:user)
+    user = create :user
+    doc = TestDocument.create body: "@#{user.login}", user: create(:user)
     expect(doc.mentioned_user_ids).to eq([user.id])
     expect(doc.mentioned_user_logins).to eq([user.login])
   end
 
   it 'limit 5 mentioned user' do
     logins = ''
-    6.times { logins << " @#{Factory(:user).login}" }
-    doc = TestDocument.create body: logins, user: Factory(:user)
+    6.times { logins << " @#{create(:user).login}" }
+    doc = TestDocument.create body: logins, user: create(:user)
     expect(doc.mentioned_user_ids.count).to eq(5)
   end
 
   it 'except self user' do
-    user = Factory :user
+    user = create :user
     doc = TestDocument.create body: "@#{user.login}", user: user
     expect(doc.mentioned_user_ids.count).to eq(0)
   end
 
   it 'should get mentioned user logins' do
-    user1 = Factory :user
-    user2 = Factory :user
-    doc = TestDocument.create body: "@#{user1.login} @#{user2.login}", user: Factory(:user)
+    user1 = create :user
+    user2 = create :user
+    doc = TestDocument.create body: "@#{user1.login} @#{user2.login}", user: create(:user)
     expect(doc.mentioned_user_logins).to match_array([user1.login, user2.login])
   end
 
   it 'should send mention notification' do
-    user = Factory :user
+    user = create :user
     expect do
-      TestDocument.create body: "@#{user.login}", user: Factory(:user)
+      TestDocument.create body: "@#{user.login}", user: create(:user)
     end.to change(user.notifications.unread, :count)
 
     expect do
@@ -48,7 +48,7 @@ describe Mongoid::Mentionable, type: :model do
     end.not_to change(user.notifications.unread, :count)
 
     expect do
-      TestDocument.create(body: "@#{user.login}", user: Factory(:user)).destroy
+      TestDocument.create(body: "@#{user.login}", user: create(:user)).destroy
     end.not_to change(user.notifications.unread, :count)
   end
 end

--- a/spec/models/node_spec.rb
+++ b/spec/models/node_spec.rb
@@ -15,12 +15,12 @@ describe Node, type: :model do
 
     it 'should update on save' do
       CacheVersion.section_node_updated_at = old
-      Factory(:node)
+      create(:node)
       expect(CacheVersion.section_node_updated_at).not_to eq(old)
     end
 
     it 'should update on destroy' do
-      node = Factory(:node)
+      node = create(:node)
       CacheVersion.section_node_updated_at = old
       node.destroy
       expect(CacheVersion.section_node_updated_at).not_to eq(old)
@@ -28,7 +28,7 @@ describe Node, type: :model do
   end
 
   describe '.summary_html' do
-    let(:node) { FactoryGirl.create(:node) }
+    let(:node) { create(:node) }
     it 'should return html' do
       node.summary = '# foo'
       expect(node.summary_html).to eq "<h1>foo</h1>\n"
@@ -44,7 +44,7 @@ describe Node, type: :model do
   end
 
   describe '.new_topic_dropdowns' do
-    let(:nodes) { FactoryGirl.create_list(:node, 10) }
+    let(:nodes) { create_list(:node, 10) }
 
     before do
       SiteConfig.new_topic_dropdown_node_ids = nodes.collect(&:id).join(',')

--- a/spec/models/notification/mention_spec.rb
+++ b/spec/models/notification/mention_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
 describe Notification::Mention, type: :model do
-  let(:topic) { Factory.create(:topic) }
-  let(:n_topic) { Factory.create(:notification_mention, mentionable: topic) }
-  let(:topic1) { Factory.create(:topic) }
-  let(:reply) { Factory.create(:reply, topic: topic1) }
-  let(:n_reply) { Factory.create(:notification_mention, mentionable: reply) }
+  let(:topic) { create(:topic) }
+  let(:n_topic) { create(:notification_mention, mentionable: topic) }
+  let(:topic1) { create(:topic) }
+  let(:reply) { create(:reply, topic: topic1) }
+  let(:n_reply) { create(:notification_mention, mentionable: reply) }
 
   describe '.content_path' do
     it 'should work' do

--- a/spec/models/notification/topic_reply_spec.rb
+++ b/spec/models/notification/topic_reply_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe Notification::TopicReply, type: :model do
-  let(:n1) { Factory.create(:notification_topic_reply) }
+  let(:n1) { create(:notification_topic_reply) }
   describe '.content_path' do
     it 'should work' do
       expect(n1.content_path).to eq("/topics/#{n1.reply.topic_id}")

--- a/spec/models/section_spec.rb
+++ b/spec/models/section_spec.rb
@@ -5,12 +5,12 @@ describe Section, type: :model do
     let(:old) { 1.minutes.ago }
     it 'should update on save' do
       CacheVersion.section_node_updated_at = old
-      Factory(:section)
+      create(:section)
       expect(CacheVersion.section_node_updated_at).not_to eq(old)
     end
 
     it 'should update on destroy' do
-      section = Factory(:section)
+      section = create(:section)
       CacheVersion.section_node_updated_at = old
       section.destroy
       expect(CacheVersion.section_node_updated_at).not_to eq(old)

--- a/spec/models/site_config_spec.rb
+++ b/spec/models/site_config_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe SiteConfig, type: :model do
-  let!(:config) { Factory :site_config }
+  let!(:config) { create :site_config }
 
   describe '#update_cache' do
     it 'should update cache' do
@@ -23,7 +23,7 @@ describe SiteConfig, type: :model do
 
   describe 'save_default' do
     it 'should create config if not exist' do
-      attributes = Factory.attributes_for :site_config
+      attributes = attributes_for :site_config
       expect(SiteConfig).to receive(:create).with(key: attributes[:key], value: attributes[:value])
       SiteConfig.save_default(attributes[:key], attributes[:value])
     end

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe Site, type: :model do
-  let(:site_node) { Factory :site_node }
+  let(:site_node) { create :site_node }
 
   it 'can add favicon default when it not provide' do
     site = Site.create(name: 'Foo bar', url: 'http://foobar.com', site_node: site_node)
@@ -14,30 +14,30 @@ describe Site, type: :model do
   end
 
   it 'should clean url to only domain' do
-    site = Factory(:site, url: 'http://bar1.com')
+    site = create(:site, url: 'http://bar1.com')
     expect(site.reload.url).to eq('http://bar1.com')
-    site = Factory(:site, url: 'https://bar2.com')
+    site = create(:site, url: 'https://bar2.com')
     expect(site.reload.url).to eq('http://bar2.com')
-    site = Factory(:site, url: 'http://bar3.com/')
+    site = create(:site, url: 'http://bar3.com/')
     expect(site.reload.url).to eq('http://bar3.com')
-    site = Factory(:site, url: 'bar4.com')
+    site = create(:site, url: 'bar4.com')
     expect(site.reload.url).to eq('http://bar4.com')
-    site = Factory(:site, url: 'bar5.com/')
+    site = create(:site, url: 'bar5.com/')
     expect(site.reload.url).to eq('http://bar5.com')
-    site = Factory(:site, url: 'http://bar6.com/bar')
+    site = create(:site, url: 'http://bar6.com/bar')
     expect(site.reload.url).to eq('http://bar6.com/bar')
   end
 
   it 'should not add again when url was deleted' do
-    site = Factory(:site, url: 'google.com')
+    site = create(:site, url: 'google.com')
     site.destroy
-    site = Factory.build(:site, url: 'google.com')
+    site = build(:site, url: 'google.com')
     site.valid?
     expect(site.errors[:url].size).to eq(1)
-    site = Factory.build(:site, url: 'google.com/')
+    site = build(:site, url: 'google.com/')
     site.valid?
     expect(site.errors[:url].size).to eq(1)
-    site = Factory.build(:site, url: 'http://google.com')
+    site = build(:site, url: 'http://google.com')
     site.valid?
     expect(site.errors[:url].size).to eq(1)
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,12 +2,12 @@ require 'rails_helper'
 require 'digest/md5'
 
 describe User, type: :model do
-  let(:topic) { Factory :topic }
-  let(:user)  { Factory :user }
-  let(:user2) { Factory :user }
-  let(:reply) { Factory :reply }
-  let(:user_for_delete1) { Factory :user }
-  let(:user_for_delete2) { Factory :user }
+  let(:topic) { create :topic }
+  let(:user)  { create :user }
+  let(:user2) { create :user }
+  let(:reply) { create :reply }
+  let(:user_for_delete1) { create :user }
+  let(:user_for_delete2) { create :user }
 
   describe '#read_topic?' do
     before do
@@ -40,7 +40,7 @@ describe User, type: :model do
   end
 
   describe '#filter_readed_topics' do
-    let(:topics) { FactoryGirl.create_list(:topic, 3) }
+    let(:topics) { create_list(:topic, 3) }
 
     it 'should work' do
       user.read_topic(topics[1])
@@ -69,7 +69,7 @@ describe User, type: :model do
       old_name = user.location
       new_name = 'HongKong'
       old_location = Location.find_by_name(old_name)
-      hk_location = Factory(:location, name: new_name, users_count: 20)
+      hk_location = create(:location, name: new_name, users_count: 20)
       user.location = new_name
       user.save
       user.reload
@@ -81,7 +81,7 @@ describe User, type: :model do
   end
 
   describe 'admin?' do
-    let(:admin) { Factory :admin }
+    let(:admin) { create :admin }
     it 'should know you are an admin' do
       expect(admin).to be_admin
     end
@@ -92,7 +92,7 @@ describe User, type: :model do
   end
 
   describe 'wiki_editor?' do
-    let(:admin) { Factory :admin }
+    let(:admin) { create :admin }
     it 'should know admin is wiki editor' do
       expect(admin).to be_wiki_editor
     end
@@ -132,38 +132,38 @@ describe User, type: :model do
     subject { user }
 
     context 'when is a new user' do
-      let(:user) { Factory :user }
+      let(:user) { create :user }
       it { is_expected.to have_role(:member) }
     end
 
     context 'when is a blocked user' do
-      let(:user) { Factory :blocked_user }
+      let(:user) { create :blocked_user }
       it { is_expected.not_to have_role(:member) }
     end
 
     context 'when is a deleted user' do
-      let(:user) { Factory :blocked_user }
+      let(:user) { create :blocked_user }
       it { is_expected.not_to have_role(:member) }
     end
 
     context 'when is admin' do
-      let(:user) { Factory :admin }
+      let(:user) { create :admin }
       it { is_expected.to have_role(:admin) }
     end
 
     context 'when is wiki editor' do
-      let(:user) { Factory :wiki_editor }
+      let(:user) { create :wiki_editor }
       it { is_expected.to have_role(:wiki_editor) }
     end
 
     context 'when ask for some random role' do
-      let(:user) { Factory :user }
+      let(:user) { create :user }
       it { is_expected.not_to have_role(:savior_of_the_broken) }
     end
   end
 
   describe 'github url' do
-    subject { Factory(:user, github: 'monkey') }
+    subject { create(:user, github: 'monkey') }
     let(:expected) { 'https://github.com/monkey' }
 
     context 'user name provided correct' do
@@ -212,9 +212,9 @@ describe User, type: :model do
   end
 
   describe 'Like' do
-    let(:topic) { Factory :topic }
-    let(:user)  { Factory :user }
-    let(:user2) { Factory :user }
+    let(:topic) { create :topic }
+    let(:user)  { create :user }
+    let(:user2) { create :user }
 
     describe 'like topic' do
       it 'can like/unlike topic' do
@@ -259,7 +259,7 @@ describe User, type: :model do
   end
 
   describe '#find_login' do
-    let(:user) { Factory :user }
+    let(:user) { create :user }
 
     it 'should work' do
       u = User.find_login(user.login)
@@ -285,7 +285,7 @@ describe User, type: :model do
   end
 
   describe '.block_node' do
-    let(:user) { Factory :user }
+    let(:user) { create :user }
 
     it 'should work' do
       user.block_node(1)
@@ -300,7 +300,7 @@ describe User, type: :model do
   end
 
   describe '.block_user' do
-    let(:user) { Factory :user }
+    let(:user) { create :user }
 
     it 'should work' do
       user.block_user(1)
@@ -315,9 +315,9 @@ describe User, type: :model do
   end
 
   describe '.follow_user' do
-    let(:u1) { Factory :user }
-    let(:u2) { Factory :user }
-    let(:u3) { Factory :user }
+    let(:u1) { create :user }
+    let(:u2) { create :user }
+    let(:u3) { create :user }
 
     it 'should work' do
       u1.follow_user(u2)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -61,4 +61,6 @@ RSpec.configure do |config|
   config.include Devise::TestHelpers, type: :controller
   config.include RSpec::Rails::RequestExampleGroup, type: :request, file_path: %r{spec/api}
   config.include APIV3Support, type: :request, file_path: %r{spec/api/v3}
+
+  config.include FactoryGirl::Syntax::Methods
 end

--- a/spec/support/api_v3_support.rb
+++ b/spec/support/api_v3_support.rb
@@ -2,8 +2,8 @@ module APIV3Support
   extend ActiveSupport::Concern
 
   included do
-    let!(:current_user) { Factory :user }
-    let!(:access_token) { Factory(:access_token, resource_owner_id: current_user.id) }
+    let!(:current_user) { create :user }
+    let!(:access_token) { create(:access_token, resource_owner_id: current_user.id) }
     let(:json) { JSON.parse(response.body) }
 
     def login_user!


### PR DESCRIPTION
* 偶然发现factory_girl的版本非常老, 一些新的特性如`after(:create)` callback不能使用，在fork里面写测试不太方便。
* spec中constructor的用法非常不一致，`FactoryGirl.create`, `Factory.create`和`Factory :user`都有。