### PR TITLE
修复代码中 =@xx 高亮被分成 =@ 和 xx 的情况

### DIFF
--- a/lib/markdown.rb
+++ b/lib/markdown.rb
@@ -195,7 +195,7 @@ class MarkdownTopicConverter < MarkdownConverter
   # syntax class.
   def link_mention_user_in_code(doc, users)
     doc.css('pre.highlight span').each do |node|
-      next unless node.previous && node.previous.inner_html == '@' && node.inner_html =~ /\Auser(\d+)\z/
+      next unless node.previous && node.previous.inner_html.to_s =~ /(^|[^a-zA-Z0-9_!#\$%&*@＠])@\z/i && node.inner_html =~ /\Auser(\d+)\z/
       user_id = Regexp.last_match(1)
       user = users[user_id.to_i - 1]
       node.inner_html = user if user

--- a/spec/lib/markdown_spec.rb
+++ b/spec/lib/markdown_spec.rb
@@ -237,6 +237,20 @@ describe 'markdown' do
           expect(doc.to_html).to include('var')
         end
       end
+
+      context '=@var in sql' do
+        let(:raw) do
+          <<-MD.gsub(/^ {12}/, '')
+            ```sql
+            select (@x:=@var+1) as i
+            ```
+          MD
+        end
+
+        it 'should not leave it as placeholder' do
+          expect(doc.to_html).to include('var')
+        end
+      end
     end
 
     # }}}


### PR DESCRIPTION
https://ruby-china.org/topics/27458