### PR TITLE
Add 16x16 SVG mask icon for Safari pinned icon.

### DIFF
--- a/app/assets/images/mask.svg
+++ b/app/assets/images/mask.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="16px" height="16px" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
+    <!-- Generator: Sketch 3.3.3 (12081) - http://www.bohemiancoding.com/sketch -->
+    <title>16</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" sketch:type="MSPage">
+        <g id="16" sketch:type="MSArtboardGroup" fill="#BD2D2D">
+            <path d="M2.71701046,3.15453128 L0.259119479,7.56452541 L0,10.3722645 L1.29063001,13.3951672 C1.29063001,13.3951672 2.38438804,14.7573624 2.63951547,14.9987689 C2.89464289,15.2401755 2.98836305,15.2548488 3.3052543,15.3014443 C3.62214555,15.3480398 14.3359798,15.5 14.4735838,15.5 C14.6111877,15.5 14.6396575,15.4521693 14.6728722,15.301444 C14.706087,15.1507188 15.9754851,4.48107759 15.9968374,4.32323615 C16.0181898,4.16539471 15.9280355,3.95015638 15.8283912,3.81383878 C15.728747,3.67752117 14.348769,2.10711283 14.348769,2.10711283 L11.2740328,0.5 L7.93357861,0.614793774 L2.71701046,3.15453128 Z" id="Path-1" sketch:type="MSShapeGroup"></path>
+        </g>
+    </g>
+</svg>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,6 +26,7 @@
   <link rel="apple-touch-icon-precomposed" href="<%= cached_asset_path("ios-icon.png") %>" />
   <link rel="shortcut icon" href="<%= cached_asset_path("big_logo.png") %>" />
   <link rel="alternate" type="application/rss+xml" title="订阅最新帖" href="<%= feed_topics_url %>" />
+  <link rel="mask-icon" href="<%= cached_asset_path("mask.svg") %>" color="#BD2D2D" />
   <%= stylesheet_link_tag_with_cached "front" %>
   <%= javascript_include_tag_with_cached "app" %>
   <%= csrf_meta_tag %>


### PR DESCRIPTION
See
https://developer.apple.com/library/prerelease/ios/documentation/AppleApplications/Reference/SafariWebContent/pinnedTabs/pinnedTabs.html

<img width="55" alt="screen shot 2015-10-10 at 11 11 55 am" src="https://cloud.githubusercontent.com/assets/35768/10409010/cee77b36-6f41-11e5-9c66-724d86d714b0.png">
