### PR TITLE
添加 Vagrant 配置

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ tags
 chromedriver.log
 .idea/
 spec/examples.txt
+.vagrant

--- a/Gemfile
+++ b/Gemfile
@@ -131,7 +131,7 @@ group :development, :test do
   gem 'colorize'
   gem 'letter_opener'
 
-  gem 'puma'
+  gem 'puma', '~> 2.14.0'
 
   # Better Errors
   gem 'better_errors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -283,7 +283,7 @@ GEM
       postmark (>= 0.9.0)
       rake
     powerpack (0.1.1)
-    puma (2.12.0)
+    puma (2.14.0)
     rack (1.6.4)
     rack-accept (0.4.5)
       rack (>= 0.4)
@@ -478,7 +478,7 @@ DEPENDENCIES
   parallel
   postmark (= 0.9.15)
   postmark-rails (= 0.4.1)
-  puma
+  puma (~> 2.14.0)
   rack-cors
   rack-mini-profiler
   rack-utf8_sanitizer

--- a/README.md
+++ b/README.md
@@ -14,8 +14,29 @@ This is the source code of [Ruby China](http://ruby-china.org) website.
 
 ## Install in development
 
+### Vagrant
 
-**Mac OS X, use Homebrew**
+Install VirtualBox:
+
+https://www.virtualbox.org/
+
+Install Vagrant:
+
+https://www.vagrantup.com/
+
+Then:
+
+```bash
+$ vagrant up
+$ vagrant ssh
+$ cd /vagrant
+/vagrant $ ./bin/setup
+/vagrant $ rails s -b 0.0.0.0
+```
+
+Open http://localhost:3000 in host.
+
+### Mac OS X, use Homebrew
 
 ```bash
 $ ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
@@ -25,7 +46,7 @@ $ brew install mongodb
 $ brew install imagemagick
 ```
 
-**Ubuntu***
+### Ubuntu
 
 ```bash
 $ sudo apt-get install memcached mongodb redis-server imagemagick

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,5 +5,5 @@ Vagrant.configure(2) do |config|
   config.vm.box = "ubuntu/precise64"
   config.vm.hostname = "ruby-china-dev"
   config.vm.network "forwarded_port", guest: 3000, host: 3000
-  config.vm.provision "shell", path: "bin/provision.sh"
+  config.vm.provision "shell", path: "bin/provision.sh", privileged: false
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,9 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure(2) do |config|
+  config.vm.box = "ubuntu/precise64"
+  config.vm.hostname = "ruby-china-dev"
+  config.vm.network "forwarded_port", guest: 3000, host: 3000
+  config.vm.provision "shell", path: "bin/provision.sh"
+end

--- a/bin/provision.sh
+++ b/bin/provision.sh
@@ -1,13 +1,17 @@
-update-locale LC_ALL="en_US.utf8"
+sudo update-locale LC_ALL="en_US.utf8"
 
 # Add mongodb sources
-apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
-echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | tee /etc/apt/sources.list.d/mongodb.list
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
+echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list
 
 # Add Ruby sources
-sudo apt-add-repository ppa:brightbox/ruby-ng
+sudo apt-add-repository -y ppa:brightbox/ruby-ng
 
-apt-get update
-apt-get install -y git redis-server memcached imagemagick mongodb-10gen ruby2.2 ruby2.2-dev nodejs
+sudo apt-get update
+sudo apt-get upgrade -y
+sudo apt-get install -y git redis-server memcached imagemagick mongodb-10gen ruby2.2 ruby2.2-dev nodejs
 
-gem install bundler
+gem sources --add https://ruby.taobao.org/ --remove https://rubygems.org/
+
+sudo gem install bundler
+bundle config mirror.https://rubygems.org https://ruby.taobao.org

--- a/bin/provision.sh
+++ b/bin/provision.sh
@@ -1,0 +1,13 @@
+update-locale LC_ALL="en_US.utf8"
+
+# Add mongodb sources
+apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
+echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | tee /etc/apt/sources.list.d/mongodb.list
+
+# Add Ruby sources
+sudo apt-add-repository ppa:brightbox/ruby-ng
+
+apt-get update
+apt-get install -y git redis-server memcached imagemagick mongodb-10gen ruby2.2 ruby2.2-dev nodejs
+
+gem install bundler

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -21,7 +21,7 @@ Rails.application.configure do
   # Print deprecation notices to the Rails logger
   config.active_support.deprecation = :log
 
-  config.assets.debug = true
+  config.assets.debug = false
 
   # Asset digests allow you to set far-future HTTP expiration dates on all assets,
   # yet still be able to expire them through the digest params.
@@ -30,7 +30,7 @@ Rails.application.configure do
   # Adds additional error checking when serving assets at runtime.
   # Checks for improperly declared sprockets dependencies.
   # Raises helpful error messages.
-  config.assets.raise_runtime_errors = true
+  config.assets.raise_runtime_errors = false
 
   config.active_job.queue_adapter = :inline
 


### PR DESCRIPTION
方便搭建开发环境，用法：

安装 VirtualBox 

https://www.virtualbox.org/

安装 Vagrant

https://www.vagrantup.com/

进入项目目录，然后:

```console
$ vagrant up
$ vagrant ssh
$ cd /vagrant
/vagrant $ ./bin/setup
/vagrant $ rails s -b 0.0.0.0
```

`vagrant up` 首次执行要下载系统镜像、安装系统依赖，根据网速不同可能要半个多小时。

然后在主机打开 localhost:3000 访问。在主机用任意编辑器编辑，修改会自动同步到虚拟机里面。

性能方面还有一些问题：

1. config/environments/development.rb 里面的配置 `config.assets.raise_runtime_errors = true` 大概会拖慢 150ms，我觉得可以关掉。
2. VirtualBox 的文件共享会拖慢速度，大概会增加一倍渲染时间，换用 NFS 可以解决。不过 sprockets 不知道什么问题， 3.0+ 版本用 NFS 共享反而会变慢，降到 2.12 就没有问题。暂时不知道怎么解决，如果性能可以接受可以不管。