### PR TITLE
把密码长度限制改成 6..128

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -111,7 +111,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length
-  config.password_length = 6..20
+  config.password_length = 6..128
 
   # Regex to use to validate the email address
   # before updating rails 4:


### PR DESCRIPTION
20 对于在意安全的人来说太短了， 太长可能增加计算负担，所以上限改到 128。

https://twitter.com/lrz/status/653925934274375680