### PR TITLE
fix whole page is orange in android wechat and qqbrowser

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -417,6 +417,7 @@ kbd {
 }
 
 html.turbolinks-progress-bar::before {
+  position: absolute !important;
   background-color: $red !important;
   height: 2px !important;
 }


### PR DESCRIPTION
修改以下issue中提到的bug，无需修改turbolinks.js的源码
https://github.com/ruby-china/ruby-china/issues/462
