### PR TITLE
修复切换语言时由于turbolinks无刷新切换导致timeago的不正确加载

### DIFF
--- a/app/assets/javascripts/app.coffee
+++ b/app/assets/javascripts/app.coffee
@@ -52,7 +52,6 @@ AppView = Backbone.View.extend
       window._noteView = new NoteView({parentView: @})
 
   initComponents: () ->
-    $("abbr.timeago").timeago()
     $(".alert").alert()
     $('.dropdown-toggle').dropdown()
     $('.bootstrap-select').remove()

--- a/app/assets/javascripts/jquery.timeago.settings.js
+++ b/app/assets/javascripts/jquery.timeago.settings.js
@@ -64,6 +64,7 @@
     if (localized) {
       jQuery.timeago.settings.strings = localized;
     }
+    $("abbr.timeago").timeago();
   });
 
 })();

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -96,7 +96,7 @@
     </script>
   <% end %>
   <script type="text/javascript" data-turbolinks-eval=always>
-      App.locale = "<%= I18n.locale %>";
+    App.locale = "<%= I18n.locale %>";
   </script>
   <script type="text/javascript" data-turbolinks-eval=false>
     App.root_url = "<%= root_url %>";

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -95,10 +95,12 @@
     $('body').animate({ scrollTop: -1 },0);
     </script>
   <% end %>
+  <script type="text/javascript" data-turbolinks-eval=always>
+      App.locale = "<%= I18n.locale %>";
+  </script>
   <script type="text/javascript" data-turbolinks-eval=false>
     App.root_url = "<%= root_url %>";
     App.asset_url = "<%= Setting.upload_url %>";
-    App.locale = "<%= I18n.locale %>";
     <% if current_user %>
       App.current_user_id = <%= current_user.id %>;
       App.access_token = "<%= current_user.temp_access_token %>";


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/6478167/10521648/971fb81a-73a3-11e5-86ee-e037bb5cb56d.png)

每次更换语言，只有刷新页面才能使`timeago`起效。

更改后正常，赋值`js`使用`data-turbolinks-eval=always`，以便前进后退保持状态。