### PR TITLE
修复 Google 统计不断在 head 插入 js 的问题

### DIFF
--- a/app/assets/javascripts/app.coffee
+++ b/app/assets/javascripts/app.coffee
@@ -22,6 +22,7 @@
 #= require topics
 #= require pages
 #= require notes
+#= require google_analytics
 #= require_self
 
 AppView = Backbone.View.extend

--- a/app/assets/javascripts/google_analytics.js
+++ b/app/assets/javascripts/google_analytics.js
@@ -1,0 +1,4 @@
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','//www.google-analytics.com/analytics.js','ga');

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -106,11 +106,6 @@
   </script>
   <%= yield :scripts %>
   <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
     ga('create', '<%= Setting.google_analytics_key %>', 'auto');
     ga('require', 'displayfeatures');
     ga('send', 'pageview');


### PR DESCRIPTION
把 ga 代码 require 到 app.js 中，这样只会执行一次。把 `ga('send', 'pageview')` 留在 body 就能完成提交统计数据。

另外 mini-profiler 也有这个问题，但它是通过 rack middleware 插入的，还没想到办法处理。