### PR TITLE
增加 "未读" 按钮来过滤未读提醒

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -24,4 +24,11 @@ class NotificationsController < ApplicationController
       format.js { render layout: false }
     end
   end
+
+  def unread
+    @notifications = current_user.notifications.unread.recent.paginate page: params[:page], per_page: 20
+    current_user.read_notifications(@notifications)
+    set_seo_meta('未读提醒')
+    render action: :index
+  end
 end

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -1,6 +1,7 @@
 <div id="notifications" class="panel panel-default">
   <div class="tools panel-heading">
     <%= link_to icon_tag("fa fa-trash", label: "清空"), clear_notifications_path, class: 'btn btn-danger', method: :post, 'data-disable-with' => '清空中...' %>
+    <%= link_to icon_tag("fa fa-filter", label: "未读"), unread_notifications_path, class: 'btn btn-info' %>
     <div class="pull-right"><h4>通知提醒</h4></div>
   </div>
   <% if @notifications.blank? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,7 @@ Rails.application.routes.draw do
   resources :notifications, only: [:index, :destroy] do
     collection do
       post :clear
+      get :unread
     end
   end
 

--- a/spec/controllers/notifications_controller_spec.rb
+++ b/spec/controllers/notifications_controller_spec.rb
@@ -9,6 +9,7 @@ describe NotificationsController, type: :controller do
       create :notification_topic_reply, user: user
       get :index
       expect(response).to render_template(:index)
+      expect(user.notifications.unread.count).to eq(0)
     end
   end
 
@@ -29,6 +30,17 @@ describe NotificationsController, type: :controller do
       3.times { create :notification_mention, user: user, mentionable: create(:reply) }
 
       post :clear
+      expect(user.notifications.unread.count).to eq(0)
+    end
+  end
+
+  describe 'unread' do
+    it 'should show unread only' do
+      sign_in user
+      3.times { create :notification_mention, user: user, mentionable: create(:reply) }
+      1.times { create :notification_mention, user: user, mentionable: create(:reply), read: true }
+      get :unread
+      expect(assigns(:notifications).count).to eq(3)
       expect(user.notifications.unread.count).to eq(0)
     end
   end


### PR DESCRIPTION
修改部分rspec，在读取提醒后自动设置为已读。

如未读提醒为较早的话，会出现在后面几页，使得那个未读一直无法清零。有的用户（比如我）不喜欢用清除，反而喜欢留着历史提醒。