### PR TITLE
在通知中，点击link会自动跳转到回复的内容

### DIFF
--- a/app/helpers/topics_helper.rb
+++ b/app/helpers/topics_helper.rb
@@ -41,9 +41,15 @@ module TopicsHelper
     link_to(raw("#{icon} 关注"), '#', 'data-id' => topic.id, 'data-followed' => followed, class: class_name)
   end
 
-  def topic_title_tag(topic)
+  def topic_title_tag(topic, opts = {})
     return t('topics.topic_was_deleted') if topic.blank?
-    link_to(topic.title, topic_path(topic), title: topic.title)
+    if opts[:reply]
+      page, index = topic.page_floor_of_reply(opts[:reply])
+      path = topic_path(topic, anchor: "reply#{index}", page: page)
+    else
+      path = topic_path(topic)
+    end
+    link_to(topic.title, path, title: topic.title)
   end
 
   def topic_excellent_tag(topic)

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -174,7 +174,7 @@ class Topic
   # 所有的回复编号
   def reply_ids
     Rails.cache.fetch([self, 'reply_ids']) do
-      replies.only(:_id).map(&:_id)
+      replies.only(:_id).map(&:_id).sort
     end
   end
 
@@ -184,6 +184,11 @@ class Topic
 
   def ban!
     update_attributes(lock_node: true, node_id: Node.no_point_id, admin_editing: true)
+  end
+
+  def page_floor_of_reply(reply)
+    reply_index = reply_ids.index(reply.id)
+    [reply_index / Reply.per_page + 1, reply_index + 1]
   end
 
   def self.notify_topic_created(topic_id)

--- a/app/views/notifications/notification/_topic_reply.erb
+++ b/app/views/notifications/notification/_topic_reply.erb
@@ -14,7 +14,7 @@
         <%= user_name_tag(reply.user) %>
       </span>
       <span class="info">在帖子
-      <%= topic_title_tag(topic) %> 回复了：</span>
+      <%= topic_title_tag(topic, reply: reply) %> 回复了：</span>
       <% if !notification.read? %>
         <span class="new label label-warning">新</span>
       <% end %>

--- a/spec/helpers/topics_helper_spec.rb
+++ b/spec/helpers/topics_helper_spec.rb
@@ -176,6 +176,28 @@ describe TopicsHelper, type: :helper do
     end
   end
 
+  describe 'topic_title_tag' do
+    let(:topic) { create :topic, title: 'test title'}
+    let(:user) { create :user }
+
+    it 'should return topic_was_deleted without a topic' do
+      expect(helper.topic_title_tag(nil)).to eq(t('topics.topic_was_deleted'))
+    end
+
+    it 'should return title with a topic' do
+      expect(helper.topic_title_tag(topic)).to eq("<a title=\"#{topic.title}\" href=\"/topics/#{topic.id}\">#{topic.title}</a>")
+    end
+
+    it 'should return page and floor with a reply' do
+      replies = []
+      52.times do |e|
+        replies << create(:reply, topic: topic, user: user)
+      end
+      expect(helper.topic_title_tag(topic, reply: replies[21])).to eq("<a title=\"#{topic.title}\" href=\"/topics/#{topic.id}?page=1#reply22\">#{topic.title}</a>")
+      expect(helper.topic_title_tag(topic, reply: replies[51])).to eq("<a title=\"#{topic.title}\" href=\"/topics/#{topic.id}?page=2#reply52\">#{topic.title}</a>")
+    end
+  end
+
   describe 'topic_follow_tag' do
     let(:topic) { create :topic }
     let(:user) { create :user }

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -69,6 +69,18 @@ describe Topic, type: :model do
     expect(t.body_html).to eq('<p><em>foo</em></p>')
   end
 
+  it 'should get page and floor by reply' do
+    replies = []
+    100.times do |e|
+      replies << create(:reply, topic: topic, user: user)
+    end
+    expect(topic.page_floor_of_reply(replies[50])).to eq([2, 51])
+    expect(topic.page_floor_of_reply(replies[35])).to eq([1, 36])
+    expect(topic.page_floor_of_reply(replies[0])).to eq([1, 1])
+    expect(topic.page_floor_of_reply(replies[74])).to eq([2, 75])
+    expect(topic.page_floor_of_reply(replies[99])).to eq([2, 100])
+  end
+
   it 'should covert body on save' do
     t = create(:topic, body: '*foo*')
     old_html = t.body_html


### PR DESCRIPTION
添加page_floor_of_reply 到topic model里面
添加reply作为topic_title_tag的可选参数，当带有reply时，link将包含#replyXXX
和page，点击link将直接跳到该reply上去。