### PR TITLE
修复自己重复赞取消赞自己的帖子，赞的数量会一直减1

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -309,6 +309,7 @@ class User
   def unlike(likeable)
     return false if likeable.blank?
     return false unless liked?(likeable)
+    return false if likeable.user_id == self.id
     likeable.pull(liked_user_ids: id)
     likeable.inc(likes_count: -1)
     likeable.touch

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -243,6 +243,12 @@ describe User, type: :model do
         expect(topic.likes_count).to eq(1)
         expect(topic.liked_user_ids).not_to include(topic.user_id)
 
+        # can't unlike itself
+        topic.user.unlike(topic)
+        topic.reload
+        expect(topic.likes_count).to eq(1)
+        expect(topic.liked_user_ids).not_to include(topic.user_id)
+
         expect {
           user.like(reply)
         }.to change(reply, :likes_count).by(1)


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/6478167/10658647/6884c8d8-78cb-11e5-867d-589df0385342.png)

如上图，本来想点一下赞自己的帖子的，觉得那个动画效果挺好的，于是狂点了N次，这下好了，从8个赞变成-10个赞了。