### PR TITLE
修正用户主页 Sidebar data-turbolinks-permanent 的问题

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,7 +4,6 @@ class UsersController < ApplicationController
   before_action :find_user, only: [:show, :topics, :replies, :favorites, :notes,
                                    :block, :unblock, :blocked,
                                    :follow, :unfollow, :followers, :following]
-  caches_action :index, expires_in: 2.hours, layout: false
 
   def index
     @total_user_count = User.count

--- a/app/views/users/_sidebar.html.erb
+++ b/app/views/users/_sidebar.html.erb
@@ -1,4 +1,4 @@
-<div class="sidebar col-md-4" id='sidebar' data-turbolinks-permanent>
+<div class="sidebar col-md-4" id='sidebar'>
   <div class="panel profile panel-default">
     <div class="panel-body">
       <div class="media">


### PR DESCRIPTION
- 同一页访问其他用户 Sidebar 不会变;
- 去掉 /users 页面的 cache，因为 View 上面有和用户有关的 Follow 状态;
