### PR TITLE
Translate missing

### DIFF
--- a/config/locales/menu.en.yml
+++ b/config/locales/menu.en.yml
@@ -44,6 +44,7 @@
     vip_user: "VIP"
     normal_user: "Member"
     newbie_user: "Newbie"
+    blocked_user: "Blocked User"
     title: "Title"
     reply_count: "Reply count"
     last_reply_time: "Last replied at"


### PR DESCRIPTION
+ https://ruby-china.org/jack8848(I can see "translation missing: en.common.blocked_user")
+ blocked user has no translate key in English language.