### PR TITLE
去掉回复列表的分页

### DIFF
--- a/app/assets/javascripts/app.coffee
+++ b/app/assets/javascripts/app.coffee
@@ -82,10 +82,13 @@ AppView = Backbone.View.extend
       location.href = "/account/sign_in"
       return false
 
-    $el = $(e.currentTarget)
-    likeable_type = $el.data("type")
-    likeable_id = $el.data("id")
-    likes_count = parseInt($el.data("count"))
+    $target = $(e.currentTarget)
+    likeable_type = $target.data("type")
+    likeable_id = $target.data("id")
+    likes_count = parseInt($target.data("count"))
+
+    $el = $(".likeable[data-type='#{likeable_type}'][data-id='#{likeable_id}']")
+
     if $el.data("state") != "active"
       $.ajax
         url : "/likes"

--- a/app/assets/javascripts/app.coffee
+++ b/app/assets/javascripts/app.coffee
@@ -86,7 +86,7 @@ AppView = Backbone.View.extend
     likeable_type = $el.data("type")
     likeable_id = $el.data("id")
     likes_count = parseInt($el.data("count"))
-    if $el.data("state") != "followed"
+    if $el.data("state") != "active"
       $.ajax
         url : "/likes"
         type : "POST"
@@ -105,7 +105,7 @@ AppView = Backbone.View.extend
           type : likeable_type
       if likes_count > 0
         likes_count -= 1
-      $el.data("state","").data('count', likes_count).attr("title", "").removeClass("followed")
+      $el.data("state","").data('count', likes_count).attr("title", "").removeClass("active")
       if likes_count == 0
         $('span',$el).text("")
       else
@@ -115,7 +115,7 @@ AppView = Backbone.View.extend
 
   likeableAsLiked : (el) ->
     likes_count = el.data("count")
-    el.data("state","followed").attr("title", "取消赞").addClass("followed")
+    el.data("state","active").attr("title", "取消赞").addClass("active")
     $('span',el).text("#{likes_count} 个赞")
     $("i.fa",el).attr("class","fa fa-thumbs-up")
 
@@ -211,7 +211,7 @@ AppView = Backbone.View.extend
     currentSrc = img.attr('src')
     img.attr('src', currentSrc.split('?')[0] + '?' + (new Date()).getTime())
     return false
-    
+
 window.App =
   locale: 'zh-CN'
   notifier : null

--- a/app/assets/javascripts/topics.coffee
+++ b/app/assets/javascripts/topics.coffee
@@ -187,8 +187,10 @@ window.TopicView = Backbone.View.extend
         $(window).unbind("beforeunload")
 
   bookmark : (e) ->
-    link = $(e.currentTarget)
-    topic_id = link.data("id")
+    target = $(e.currentTarget)
+    topic_id = target.data("id")
+    link = $(".bookmark[data-id='#{topic_id}']")
+
     if link.hasClass("active")
       $.ajax
         url : "/topics/#{topic_id}/unfavorite"
@@ -200,10 +202,11 @@ window.TopicView = Backbone.View.extend
     false
 
   follow : (e) ->
-    link = $(e.currentTarget)
-    topic_id = link.data("id")
-    followed = link.hasClass("active")
-    if followed
+    target = $(e.currentTarget)
+    topic_id = target.data("id")
+    link = $(".follow[data-id='#{topic_id}']")
+
+    if link.hasClass("active")
       $.ajax
         url : "/topics/#{topic_id}/unfollow"
         type : "DELETE"

--- a/app/assets/javascripts/topics.coffee
+++ b/app/assets/javascripts/topics.coffee
@@ -11,8 +11,8 @@ window.TopicView = Backbone.View.extend
     "click #topic-upload-image": "browseUpload"
     "click .insert-codes a": "appendCodesFromHint"
     "click a.at_floor": "clickAtFloor"
-    "click .topic-detail a.follow": "follow"
-    "click .topic-detail a.bookmark": "bookmark"
+    "click a.follow": "follow"
+    "click a.bookmark": "bookmark"
 
   initialize: (opts) ->
     @parentView = opts.parentView
@@ -189,30 +189,30 @@ window.TopicView = Backbone.View.extend
   bookmark : (e) ->
     link = $(e.currentTarget)
     topic_id = link.data("id")
-    if link.hasClass("followed")
+    if link.hasClass("active")
       $.ajax
         url : "/topics/#{topic_id}/unfavorite"
         type : "DELETE"
-      link.attr("title","收藏").removeClass("followed")
+      link.attr("title","收藏").removeClass("active")
     else
       $.post "/topics/#{topic_id}/favorite"
-      link.attr("title","取消收藏").addClass("followed")
+      link.attr("title","取消收藏").addClass("active")
     false
 
   follow : (e) ->
     link = $(e.currentTarget)
     topic_id = link.data("id")
-    followed = link.data("followed")
+    followed = link.hasClass("active")
     if followed
       $.ajax
         url : "/topics/#{topic_id}/unfollow"
         type : "DELETE"
-      link.data("followed", false).removeClass("followed")
+      link.removeClass("active")
     else
       $.ajax
         url : "/topics/#{topic_id}/follow"
         type : "POST"
-      link.data("followed", true).addClass("followed")
+      link.addClass("active")
     false
 
   submitTextArea : (e) ->

--- a/app/assets/javascripts/topics.coffee
+++ b/app/assets/javascripts/topics.coffee
@@ -1,6 +1,5 @@
 # TopicsController 下所有页面的 JS 功能
 window.Topics =
-  replies_per_page: 50
   user_liked_reply_ids: []
 
 window.TopicView = Backbone.View.extend
@@ -77,10 +76,6 @@ window.TopicView = Backbone.View.extend
     reply_body.focus().val(reply_body.val() + new_text)
     return false
 
-  # Given floor, calculate which page this floor is in
-  pageOfFloor: (floor) ->
-    Math.floor((floor - 1) / Topics.replies_per_page) + 1
-
   clickAtFloor: (e) ->
     floor = $(e.target).data('floor')
     @gotoFloor(floor)
@@ -92,13 +87,7 @@ window.TopicView = Backbone.View.extend
   gotoFloor: (floor) ->
     replyEl = $("#reply#{floor}")
 
-    if replyEl.length > 0
-      @highlightReply(replyEl)
-    else
-      page = @pageOfFloor(floor)
-      # TODO: merge existing query string
-      url = window.location.pathname + "?page=#{page}" + "#reply#{floor}"
-      App.gotoUrl url
+    @highlightReply(replyEl)
 
     replyEl
 
@@ -111,7 +100,6 @@ window.TopicView = Backbone.View.extend
 
   # 异步更改用户 like 过的回复的 like 按钮的状态
   checkRepliesLikeStatus : () ->
-    console.log Topics.user_liked_reply_ids
     for id in Topics.user_liked_reply_ids
       el = $("#replies a.likeable[data-id=#{id}]")
       @parentView.likeableAsLiked(el)

--- a/app/assets/javascripts/topics.coffee
+++ b/app/assets/javascripts/topics.coffee
@@ -8,11 +8,13 @@ window.TopicView = Backbone.View.extend
 
   events:
     "click #replies .reply .btn-reply": "reply"
+    "click .btn-focus-reply": "reply"
     "click #topic-upload-image": "browseUpload"
     "click .insert-codes a": "appendCodesFromHint"
     "click a.at_floor": "clickAtFloor"
     "click a.follow": "follow"
     "click a.bookmark": "bookmark"
+    "click .btn-move-page": "scrollPage"
 
   initialize: (opts) ->
     @parentView = opts.parentView
@@ -68,7 +70,10 @@ window.TopicView = Backbone.View.extend
     floor = _el.data("floor")
     login = _el.data("login")
     reply_body = $("#new_reply textarea")
-    new_text = "##{floor}楼 @#{login} "
+    if floor
+      new_text = "##{floor}楼 @#{login} "
+    else
+      new_text = ''
     if reply_body.val().trim().length == 0
       new_text += ''
     else
@@ -249,6 +254,16 @@ window.TopicView = Backbone.View.extend
     txtBox.caret('pos',caret_pos + src_merged.length - 5)
     txtBox.focus()
     txtBox.trigger('click')
+    return false
+
+  scrollPage: (e) ->
+    target = $(e.currentTarget)
+    moveType = target.data('type')
+    opts =
+      scrollTop: 0
+    if moveType == 'bottom'
+      opts.scrollTop = $('body').height()
+    $("body, html").animate(opts, 300)
     return false
 
   initComponents : ->

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -633,7 +633,7 @@ img.emoji { width:20px; height:20px; }
 }
 
 #topic-sidebar {
-  width: 220px;
+  width: 240px;
   .buttons {
     .group {
       text-align: center; margin-bottom: 20px;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -160,6 +160,8 @@ body {
   }
 }
 
+.sidebar { padding-left: 5px; }
+
 .dropdown-menu { border-color: #FFF; border-radius: 2px;   border-top-left-radius: 0;
   border-top-right-radius: 0; box-shadow: 0px 1px 2px rgba(0,0,0,0.15); }
 
@@ -168,7 +170,7 @@ a { color: $blue; }
 .btn {
   border-radius: 3px;
   border: 1px solid #ccc;
-  padding: 5px 18px; box-shadow: inset 0px 1px 0px 0px rgba(255, 255, 255, 0.15); }
+  padding: 5px 12px; box-shadow: inset 0px 1px 0px 0px rgba(255, 255, 255, 0.15); }
 
   .btn-default { box-shadow: inset 0px 1px 0px 0px rgba(255, 255, 255, 1);  }
 .btn-default,
@@ -633,11 +635,26 @@ img.emoji { width:20px; height:20px; }
 }
 
 #topic-sidebar {
-  width: 240px;
+  position: fixed;
+  width: 260px;
+
+
+  @media (min-width: 992px) {
+    width: 240px;
+  }
+
+  @media (min-width: 1100px) {
+    width: 260px;
+  }
+
+
+
+  .group {
+    text-align: center; margin-bottom: 20px;
+  }
+
   .buttons {
-    .group {
-      text-align: center; margin-bottom: 20px;
-    }
+    margin-top: 20px;
     .likes {
       a { display: block; width: 90px; margin: 0 auto; border-radius: 5px; padding: 10px 0;}
       a:link, a:hover, a:visited { text-decoration: none; color: #333; }
@@ -652,6 +669,7 @@ img.emoji { width:20px; height:20px; }
     text-align:center;
     .total { margin-bottom: 10px; }
   }
+  a.btn-move-page { color: #666; }
 }
 
 #replies {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -174,7 +174,7 @@ a { color: $blue; }
 .btn-default,
 .btn-default:visited { background: #eee; border-color: #dadada;  }
 .btn-default:hover { background: #eaeaea; border-color: #ddd; }
-.btn-default.active { background: $grayDark; border-color: $grayDark;}
+.btn-default.active { background: #f0f0f0; border-color: #d0d0d0;}
 .btn-primary,
 .btn-primary:visited { background: $blue; border-color: $blueDark; color: #FFF; }
 .btn-primary:hover { background: $blueLight; border-color: $blue; }
@@ -282,7 +282,7 @@ form {
   .btn-default.active {
     border: 0px;
     background: #FFF;
-    border-bottom:1px solid #D5DCDB;
+    border-bottom:1px solid #F3F3F3;
     transition: none;
     padding-bottom: 7px;
     border-radius: 0;
@@ -461,7 +461,7 @@ img.emoji { width:20px; height:20px; }
 .deleted { text-decoration: line-through; color: $grayDark; }
 .no-result { color: #aaa; padding-bottom: 20px; text-align: center;}
 
-a.followed {
+.opts a.active {
   .fa {
     @extend .animated;
     @extend .bounceIn;
@@ -629,6 +629,28 @@ a.followed {
         &:hover { color: #333; }
       }
     }
+  }
+}
+
+#topic-sidebar {
+  width: 220px;
+  .buttons {
+    .group {
+      text-align: center; margin-bottom: 20px;
+    }
+    .likes {
+      a { display: block; width: 90px; margin: 0 auto; border-radius: 5px; padding: 10px 0;}
+      a:link, a:hover, a:visited { text-decoration: none; color: #333; }
+      a:hover { background: rgba(0, 0, 0, 0.03); }
+      i.fa { display: block; font-size: 40px;  margin-bottom: 10px; color: #666; }
+      a.active {
+        i.fa { color: #DC3030; }
+      }
+    }
+  }
+  .reply-buttons {
+    text-align:center;
+    .total { margin-bottom: 10px; }
   }
 }
 

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -83,14 +83,8 @@ class TopicsController < ApplicationController
 
     @show_raw = params[:raw] == '1'
 
-    @per_page = Reply.per_page
-    # 默认最后一页
-    params[:page] = @topic.last_page_with_per_page(@per_page) if params[:page].blank?
-    @page = params[:page].to_i > 0 ? params[:page].to_i : 1
-
     @threads << Thread.new do
-      @replies = @topic.replies.unscoped.without_body.asc(:_id)
-      @replies = @replies.paginate(page: @page, per_page: @per_page)
+      @replies = @topic.replies.unscoped.without_body.asc(:_id).all
 
       check_current_user_liked_replies
     end
@@ -101,8 +95,6 @@ class TopicsController < ApplicationController
     @threads.each(&:join)
 
     set_seo_meta "#{@topic.title} &raquo; #{t('menu.topics')}"
-
-    fresh_when(etag: [@topic, @has_followed, @has_favorited, @replies, @node, @show_raw])
   end
 
   def check_current_user_liked_replies

--- a/app/helpers/likes_helper.rb
+++ b/app/helpers/likes_helper.rb
@@ -14,7 +14,7 @@ module LikesHelper
 
     if opts[:cache].blank? && likeable.liked_by_user?(current_user)
       title = '取消赞'
-      state = 'followed'
+      state = 'active'
       icon = content_tag('i', '', class: 'fa fa-thumbs-up')
     else
       title = '赞'

--- a/app/helpers/topics_helper.rb
+++ b/app/helpers/topics_helper.rb
@@ -24,8 +24,11 @@ module TopicsHelper
     end
 
     icon = raw(content_tag('i', '', class: 'fa fa-bookmark'))
+    if opts[:class].present?
+      class_name += ' ' + opts[:class]
+    end
 
-    link_to(raw("#{icon} 收藏"), '#', title: link_title, class: "#{opts[:class]} bookmark #{class_name}", 'data-id' => topic.id)
+    link_to(raw("#{icon} 收藏"), '#', title: link_title, class: "bookmark #{class_name}", 'data-id' => topic.id)
   end
 
   def topic_follow_tag(topic, opts = {})
@@ -39,7 +42,9 @@ module TopicsHelper
       class_name = 'follow active'
       followed = true
     end
-    class_name = "#{opts[:class]} #{class_name}"
+    if opts[:class].present?
+      class_name += ' ' + opts[:class]
+    end
     icon = content_tag('i', '', class: 'fa fa-eye')
     link_to(raw("#{icon} 关注"), '#', 'data-id' => topic.id, class: class_name)
   end

--- a/app/helpers/topics_helper.rb
+++ b/app/helpers/topics_helper.rb
@@ -13,32 +13,35 @@ module TopicsHelper
     end
   end
 
-  def topic_favorite_tag(topic)
+  def topic_favorite_tag(topic, opts = {})
     return '' if current_user.blank?
+    opts[:class] ||= ""
     class_name = ''
     link_title = '收藏'
     if current_user && current_user.favorite_topic_ids.include?(topic.id)
-      class_name = 'followed'
+      class_name = 'active'
       link_title = '取消收藏'
     end
 
     icon = raw(content_tag('i', '', class: 'fa fa-bookmark'))
 
-    link_to(icon, '#', title: link_title, class: "bookmark #{class_name}", 'data-id' => topic.id)
+    link_to(raw("#{icon} 收藏"), '#', title: link_title, class: "#{opts[:class]} bookmark #{class_name}", 'data-id' => topic.id)
   end
 
-  def topic_follow_tag(topic)
+  def topic_follow_tag(topic, opts = {})
     return '' if current_user.blank?
     return '' if topic.blank?
     return '' if owner?(topic)
+    opts[:class] ||= ""
     class_name = 'follow'
     followed = false
     if topic.follower_ids.include?(current_user.id)
-      class_name = 'follow followed'
+      class_name = 'follow active'
       followed = true
     end
+    class_name = "#{opts[:class]} #{class_name}"
     icon = content_tag('i', '', class: 'fa fa-eye')
-    link_to(raw("#{icon} 关注"), '#', 'data-id' => topic.id, 'data-followed' => followed, class: class_name)
+    link_to(raw("#{icon} 关注"), '#', 'data-id' => topic.id, class: class_name)
   end
 
   def topic_title_tag(topic, opts = {})

--- a/app/helpers/topics_helper.rb
+++ b/app/helpers/topics_helper.rb
@@ -44,8 +44,8 @@ module TopicsHelper
   def topic_title_tag(topic, opts = {})
     return t('topics.topic_was_deleted') if topic.blank?
     if opts[:reply]
-      page, index = topic.page_floor_of_reply(opts[:reply])
-      path = topic_path(topic, anchor: "reply#{index}", page: page)
+      index = topic.floor_of_reply(opts[:reply])
+      path = topic_path(topic, anchor: "reply#{index}")
     else
       path = topic_path(topic)
     end

--- a/app/models/reply.rb
+++ b/app/models/reply.rb
@@ -62,11 +62,6 @@ class Reply
     user.like(topic)
   end
 
-
-  def self.per_page
-    50
-  end
-
   def self.notify_reply_created(reply_id)
     reply = Reply.find_by_id(reply_id)
     return if reply.blank?

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -166,11 +166,6 @@ class Topic
     delete_notifiaction_mentions
   end
 
-  def last_page_with_per_page(per_page)
-    page = (replies_count.to_f / per_page).ceil
-    page > 1 ? page : nil
-  end
-
   # 所有的回复编号
   def reply_ids
     Rails.cache.fetch([self, 'reply_ids']) do
@@ -186,9 +181,9 @@ class Topic
     update_attributes(lock_node: true, node_id: Node.no_point_id, admin_editing: true)
   end
 
-  def page_floor_of_reply(reply)
+  def floor_of_reply(reply)
     reply_index = reply_ids.index(reply.id)
-    [reply_index / Reply.per_page + 1, reply_index + 1]
+    reply_index + 1
   end
 
   def self.notify_topic_created(topic_id)

--- a/app/views/replies/_reply.html.erb
+++ b/app/views/replies/_reply.html.erb
@@ -1,6 +1,6 @@
 <% cache([reply,"raw:#{@show_raw}"]) do %>
 <%
-  floor = reply_counter + 1 + ((@page - 1) * Reply.per_page)
+  floor = reply_counter + 1
 %>
 <div class="reply<%= ' popular' if reply.popular? %>" id="reply<%= floor %>">
   <% if reply.deleted? and !@show_raw %>

--- a/app/views/topics/_topic_sidebar.html.erb
+++ b/app/views/topics/_topic_sidebar.html.erb
@@ -1,0 +1,50 @@
+<div id="topic-sidebar">
+  <div class="panel panel-default">
+    <div class="panel-body">
+      <a href="#" class="btn btn-block btn-move-page" data-type="top"><i class="fa fa-arrow-up"></i></a>
+      <div class="buttons">
+        <div class="group likes opts">
+          <%= likeable_tag(@topic) %>
+        </div>
+        <div class="group">
+          <div class="btn-group" role="group">
+            <%= topic_follow_tag(@topic, class: 'btn btn-default') %>
+            <%= topic_favorite_tag(@topic, class: 'btn btn-default') %>
+          </div>
+        </div>
+      </div>
+
+      <hr />
+      <div class="reply-buttons">
+        <div class="total">
+          共收到 <b><%= @topic.replies_count %></b> 条回复
+        </div>
+        <a href="#reply" class="btn btn-success btn-block btn-focus-reply">参与回复</a>
+      </div>
+      <hr />
+      <div class="group opts">
+        <% if admin? %>
+          <% if !@topic.suggested_at.blank? %>
+          <%= link_to raw("<i class='fa fa-thumb-tack'></i> 取消"), unsuggest_cpanel_topic_path(@topic), 'data-confirm' => '确定要取消置顶么?', method: :post %>
+          <% else %>
+          <%= link_to raw("<i class='fa fa-thumb-tack'></i> 置顶"), suggest_cpanel_topic_path(@topic), 'data-confirm' => '确定要置顶么?', method: :post %>
+          <% end %>
+          <% if !@topic.excellent? %>
+          <%= link_to raw("<i class='fa fa-diamond'></i> 加精"), suggest_topic_path(@topic.id), title: "设为精华帖" , method: "patch", data: { confirm: "确定要设置成精华帖么？" } %>
+          <% end %>
+          <% if @topic.node_id != Node.no_point_id %>
+          <%= link_to raw("<i class='fa fa-ban'></i> 屏蔽"), ban_topic_path(@topic), method: 'post', title: "屏蔽此贴，移动到 NoPoint 节点" %>
+          <% end %>
+        <% end %>
+
+        <% if owner?(@topic) or admin? %>
+        <%= link_to "", edit_topic_path(@topic), class: "fa fa-pencil", title: "修改本帖" %>
+          <% if can?(:destroy, @topic) %>
+          <%= link_to "", topic_path(@topic.id), method: :delete, 'data-confirm' => t("common.confirm_delete"), class: "fa fa-trash", title: "删除本帖" %>
+          <% end %>
+        <% end %>
+      </div>
+      <a href="#" class="btn btn-block btn-move-page" data-type="bottom"><i class="fa fa-arrow-down"></i></a>
+    </div>
+  </div>
+</div>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -98,55 +98,8 @@
   </div>
 
 <% if !mobile? %>
-  <div class="sidebar col-md-3">
-    <div id="topic-sidebar" data-spy="affix" data-offset-top="20" data-offset-bottom="50">
-      <div class="panel panel-default">
-        <div class="panel-body">
-          <div class="buttons">
-            <div class="group likes">
-              <%= likeable_tag(@topic) %>
-            </div>
-            <div class="group">
-              <div class="btn-group" role="group">
-                <%= topic_follow_tag(@topic, class: 'btn btn-default') %>
-                <%= topic_favorite_tag(@topic, class: 'btn btn-default') %>
-              </div>
-            </div>
-          </div>
-
-          <hr />
-          <div class="reply-buttons">
-            <div class="total">
-              共收到 <b><%= @topic.replies_count %></b> 条回复
-            </div>
-            <a href="#reply" class="btn btn-success btn-block">参与回复</a>
-          </div>
-          <hr />
-          <div class="opts">
-            <% if admin? %>
-              <% if !@topic.suggested_at.blank? %>
-              <%= link_to raw("<i class='fa fa-thumb-tack'></i> 取消"), unsuggest_cpanel_topic_path(@topic), 'data-confirm' => '确定要取消置顶么?', method: :post %>
-              <% else %>
-              <%= link_to raw("<i class='fa fa-thumb-tack'></i> 置顶"), suggest_cpanel_topic_path(@topic), 'data-confirm' => '确定要置顶么?', method: :post %>
-              <% end %>
-              <% if !@topic.excellent? %>
-              <%= link_to raw("<i class='fa fa-diamond'></i> 加精"), suggest_topic_path(@topic.id), title: "设为精华帖" , method: "patch", data: { confirm: "确定要设置成精华帖么？" } %>
-              <% end %>
-              <% if @topic.node_id != Node.no_point_id %>
-              <%= link_to raw("<i class='fa fa-ban'></i> 屏蔽"), ban_topic_path(@topic), method: 'post', title: "屏蔽此贴，移动到 NoPoint 节点" %>
-              <% end %>
-            <% end %>
-
-            <% if owner?(@topic) or admin? %>
-            <%= link_to "", edit_topic_path(@topic), class: "fa fa-pencil", title: "修改本帖" %>
-              <% if can?(:destroy, @topic) %>
-              <%= link_to "", topic_path(@topic.id), method: :delete, 'data-confirm' => t("common.confirm_delete"), class: "fa fa-trash", title: "删除本帖" %>
-              <% end %>
-            <% end %>
-          </div>
-        </div>
-      </div>
-    </div>
+  <div class="sidebar hidden-mobile col-md-3">
+    <%= render 'topic_sidebar' %>
   </div>
 <% end %>
 </div>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -99,8 +99,59 @@
 
 <% if !mobile? %>
   <div class="sidebar col-md-3">
-    <%= render "sidebar_box_tips" %>
-    <%= render "sidebar_box_node_recent_topics", topic: @topic %>
+    <div id="topic-sidebar" data-spy="affix" data-offset-top="20" data-offset-bottom="50">
+      <div class="panel panel-default">
+        <div class="panel-body">
+          <div class="buttons">
+            <div class="group likes">
+              <%= likeable_tag(@topic) %>
+            </div>
+            <div class="group">
+              <div class="btn-group" role="group">
+                <%= topic_follow_tag(@topic, class: 'btn btn-default') %>
+                <%= topic_favorite_tag(@topic, class: 'btn btn-default') %>
+              </div>
+            </div>
+          </div>
+
+          <% if @topic.excellent? %>
+          <div class="excellent">
+            <%= topic_excellent_tag(@topic) %>
+          </div>
+          <% end %>
+          <hr />
+          <div class="reply-buttons">
+            <div class="total">
+              共收到 <b><%= @topic.replies_count %></b> 条回复
+            </div>
+            <a href="#reply" class="btn btn-success btn-block">回复</a>
+          </div>
+          <hr />
+          <div class="opts">
+            <% if admin? %>
+              <% if !@topic.suggested_at.blank? %>
+              <%= link_to raw("<i class='fa fa-thumb-tack'></i> 取消"), unsuggest_cpanel_topic_path(@topic), 'data-confirm' => '确定要取消置顶么?', method: :post %>
+              <% else %>
+              <%= link_to raw("<i class='fa fa-thumb-tack'></i> 置顶"), suggest_cpanel_topic_path(@topic), 'data-confirm' => '确定要置顶么?', method: :post %>
+              <% end %>
+              <% if !@topic.excellent? %>
+              <%= link_to raw("<i class='fa fa-diamond'></i> 加精"), suggest_topic_path(@topic.id), title: "设为精华帖" , method: "patch", data: { confirm: "确定要设置成精华帖么？" } %>
+              <% end %>
+              <% if @topic.node_id != Node.no_point_id %>
+              <%= link_to raw("<i class='fa fa-ban'></i> 屏蔽"), ban_topic_path(@topic), method: 'post', title: "屏蔽此贴，移动到 NoPoint 节点" %>
+              <% end %>
+            <% end %>
+
+            <% if owner?(@topic) or admin? %>
+            <%= link_to "", edit_topic_path(@topic), class: "fa fa-pencil", title: "修改本帖" %>
+              <% if can?(:destroy, @topic) %>
+              <%= link_to "", topic_path(@topic.id), method: :delete, 'data-confirm' => t("common.confirm_delete"), class: "fa fa-trash", title: "删除本帖" %>
+              <% end %>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 <% end %>
 </div>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -114,17 +114,12 @@
             </div>
           </div>
 
-          <% if @topic.excellent? %>
-          <div class="excellent">
-            <%= topic_excellent_tag(@topic) %>
-          </div>
-          <% end %>
           <hr />
           <div class="reply-buttons">
             <div class="total">
               共收到 <b><%= @topic.replies_count %></b> 条回复
             </div>
-            <a href="#reply" class="btn btn-success btn-block">回复</a>
+            <a href="#reply" class="btn btn-success btn-block">参与回复</a>
           </div>
           <hr />
           <div class="opts">

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -1,6 +1,5 @@
 <% content_for :scripts do %>
   <script type="text/javascript">
-    Topics.replies_per_page = <%= @per_page %>;
     <% if current_user && !@user_liked_reply_ids.blank? %>
     Topics.user_liked_reply_ids = [<%= @user_liked_reply_ids.join(",") %>];
     <% end %>
@@ -56,12 +55,9 @@
         共收到 <b><%= @topic.replies_count %></b> 条回复
       </div>
       <div class="items panel-body">
-        <%= cache([@topic,params[:page],"raw:#{@show_raw}"]) do %>
+        <%= cache([@topic, "raw:#{@show_raw}"]) do %>
           <%= render partial: "replies/reply", collection: @replies %>
         <% end %>
-      </div>
-      <div class="panel-footer clearfix">
-        <%= will_paginate @replies, params: { anchor: 'replies' } %>
       </div>
     </div>
   <% end %>
@@ -79,7 +75,8 @@
             <%= f.text_area :body, class: "topic-editor form-control", rows: "4", tabindex: "1" %>
           </div>
           <div class="submit-buttons">
-            <button type="submit" id="reply-button" class="btn btn-primary" tabindex="2"><%= t("topics.submit_reply")%></button> <span class="help-inline" title="或者 Ctrl + Enter"><kbd>Command</kbd> + <kbd>Enter</kbd></span>
+            <button type="submit" id="reply-button" class="btn btn-primary" tabindex="2"><%= t("topics.submit_reply")%></button>
+            <span class="help-inline" style="padding-left: 5px;" title="或者 Ctrl + Enter"><kbd>Command</kbd> + <kbd>Enter</kbd></span>
 
             <div class="pull-right"><a href="/markdown" target="_blank">排版说明</a></div>
           </div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -4,7 +4,7 @@ Rails.application.configure do
   # In the development environment your application's code is reloaded on
   # every request.  This slows down response time but is perfect for development
   # since you don't have to restart the webserver when you make code changes.
-  config.cache_classes = false
+  config.cache_classes = true
 
   config.eager_load = false
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -4,7 +4,7 @@ Rails.application.configure do
   # In the development environment your application's code is reloaded on
   # every request.  This slows down response time but is perfect for development
   # since you don't have to restart the webserver when you make code changes.
-  config.cache_classes = true
+  config.cache_classes = false
 
   config.eager_load = false
 

--- a/spec/controllers/topics_controller_spec.rb
+++ b/spec/controllers/topics_controller_spec.rb
@@ -105,20 +105,6 @@ describe TopicsController, type: :controller do
         get :show, id: topic.id
       end.to change(user.notifications.unread, :count).by(-2)
     end
-
-    context 'when the topic has 11 replies, and 10 are shown per page' do
-      let!(:user) { build_stubbed(:user) }
-      let!(:topic) { create(:topic) }
-      let!(:reply) { create_list(:reply, 11, topic: topic) }
-
-      before { sign_in user }
-
-      it 'should show the last page by default' do
-        allow(Reply).to receive(:per_page).and_return(10)
-        get :show, id: topic
-        expect(assigns[:page]).to eq(2)
-      end
-    end
   end
 
   describe '#suggest' do

--- a/spec/helpers/likes_helper_spec.rb
+++ b/spec/helpers/likes_helper_spec.rb
@@ -13,9 +13,9 @@ describe LikesHelper, type: :helper do
     it 'should result when logined user liked' do
       allow(helper).to receive(:current_user).and_return(user)
       allow(topic).to receive(:liked_by_user?).and_return(true)
-      expect(helper.likeable_tag(topic)).to eq(%(<a title=\"取消赞\" data-count=\"0\" data-state=\"followed\" data-type=\"Topic\" data-id=\"1\" class=\"likeable followed\" href=\"#\"><i class=\"fa fa-thumbs-up\"></i> <span></span></a>))
+      expect(helper.likeable_tag(topic)).to eq(%(<a title=\"取消赞\" data-count=\"0\" data-state=\"active\" data-type=\"Topic\" data-id=\"1\" class=\"likeable active\" href=\"#\"><i class=\"fa fa-thumbs-up\"></i> <span></span></a>))
       allow(topic).to receive(:likes_count).and_return(3)
-      expect(helper.likeable_tag(topic)).to eq(%(<a title=\"取消赞\" data-count=\"3\" data-state=\"followed\" data-type=\"Topic\" data-id=\"1\" class=\"likeable followed\" href=\"#\"><i class=\"fa fa-thumbs-up\"></i> <span>3 个赞</span></a>))
+      expect(helper.likeable_tag(topic)).to eq(%(<a title=\"取消赞\" data-count=\"3\" data-state=\"active\" data-type=\"Topic\" data-id=\"1\" class=\"likeable active\" href=\"#\"><i class=\"fa fa-thumbs-up\"></i> <span>3 个赞</span></a>))
     end
 
     it 'should result when unlogin user' do

--- a/spec/helpers/topics_helper_spec.rb
+++ b/spec/helpers/topics_helper_spec.rb
@@ -161,13 +161,13 @@ describe TopicsHelper, type: :helper do
       allow(user).to receive(:favorite_topic_ids).and_return([])
       allow(helper).to receive(:current_user).and_return(user)
       res = helper.topic_favorite_tag(topic)
-      expect(res).to eq("<a title=\"收藏\" class=\"bookmark \" data-id=\"1\" href=\"#\"><i class=\"fa fa-bookmark\"></i></a>")
+      expect(res).to eq("<a title=\"收藏\" class=\"bookmark \" data-id=\"1\" href=\"#\"><i class=\"fa fa-bookmark\"></i> 收藏</a>")
     end
 
     it 'should result when logined user favorited topic' do
       allow(user).to receive(:favorite_topic_ids).and_return([topic.id])
       allow(helper).to receive(:current_user).and_return(user)
-      expect(helper.topic_favorite_tag(topic)).to eq("<a title=\"取消收藏\" class=\"bookmark followed\" data-id=\"1\" href=\"#\"><i class=\"fa fa-bookmark\"></i></a>")
+      expect(helper.topic_favorite_tag(topic)).to eq("<a title=\"取消收藏\" class=\"bookmark active\" data-id=\"1\" href=\"#\"><i class=\"fa fa-bookmark\"></i> 收藏</a>")
     end
 
     it 'should result blank when unlogin user' do
@@ -211,15 +211,15 @@ describe TopicsHelper, type: :helper do
     context 'was unfollow' do
       it 'should work' do
         allow(helper).to receive(:current_user).and_return(user)
-        expect(helper.topic_follow_tag(topic)).to eq "<a data-id=\"#{topic.id}\" data-followed=\"false\" class=\"follow\" href=\"#\"><i class=\"fa fa-eye\"></i> 关注</a>"
+        expect(helper.topic_follow_tag(topic)).to eq "<a data-id=\"#{topic.id}\" class=\"follow\" href=\"#\"><i class=\"fa fa-eye\"></i> 关注</a>"
       end
     end
 
-    context 'was followed' do
+    context 'was active' do
       it 'should work' do
         allow(helper).to receive(:current_user).and_return(user)
         allow(topic).to receive(:follower_ids).and_return([user.id])
-        expect(helper.topic_follow_tag(topic)).to eq "<a data-id=\"#{topic.id}\" data-followed=\"true\" class=\"follow followed\" href=\"#\"><i class=\"fa fa-eye\"></i> 关注</a>"
+        expect(helper.topic_follow_tag(topic)).to eq "<a data-id=\"#{topic.id}\" class=\"follow active\" href=\"#\"><i class=\"fa fa-eye\"></i> 关注</a>"
       end
     end
   end

--- a/spec/helpers/topics_helper_spec.rb
+++ b/spec/helpers/topics_helper_spec.rb
@@ -187,15 +187,6 @@ describe TopicsHelper, type: :helper do
     it 'should return title with a topic' do
       expect(helper.topic_title_tag(topic)).to eq("<a title=\"#{topic.title}\" href=\"/topics/#{topic.id}\">#{topic.title}</a>")
     end
-
-    it 'should return page and floor with a reply' do
-      replies = []
-      52.times do |e|
-        replies << create(:reply, topic: topic, user: user)
-      end
-      expect(helper.topic_title_tag(topic, reply: replies[21])).to eq("<a title=\"#{topic.title}\" href=\"/topics/#{topic.id}?page=1#reply22\">#{topic.title}</a>")
-      expect(helper.topic_title_tag(topic, reply: replies[51])).to eq("<a title=\"#{topic.title}\" href=\"/topics/#{topic.id}?page=2#reply52\">#{topic.title}</a>")
-    end
   end
 
   describe 'topic_follow_tag' do

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -71,14 +71,11 @@ describe Topic, type: :model do
 
   it 'should get page and floor by reply' do
     replies = []
-    100.times do |e|
+    5.times do |e|
       replies << create(:reply, topic: topic, user: user)
     end
-    expect(topic.page_floor_of_reply(replies[50])).to eq([2, 51])
-    expect(topic.page_floor_of_reply(replies[35])).to eq([1, 36])
-    expect(topic.page_floor_of_reply(replies[0])).to eq([1, 1])
-    expect(topic.page_floor_of_reply(replies[74])).to eq([2, 75])
-    expect(topic.page_floor_of_reply(replies[99])).to eq([2, 100])
+    expect(topic.floor_of_reply(replies[2])).to eq(3)
+    expect(topic.floor_of_reply(replies[3])).to eq(4)
   end
 
   it 'should covert body on save' do


### PR DESCRIPTION
1. 去掉回复列表的分页，有 Cache 的情况，渲染还是很快的，哪怕有 200 条回复（大部分在 100 一下）
2. 用浮动的工具栏代替之前的话题 Sidebar，如下图

<img width="283" alt="2015-11-06 11 15 14" src="https://cloud.githubusercontent.com/assets/5518/10988666/6ac6fe86-8479-11e5-9f69-b8c903042a18.png">
