### PR TITLE
Upgrade rest-client, turbolinks, add bundler-audit, cleanup Rakefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,4 @@ before_script:
   - sed -i "s/SETUP_REDIS_HOST/127.0.0.1/g" config/redis.yml
   - sed -i "s/SETUP_REDIS_PORT/6379/g" config/redis.yml
 
-script: RAILS_ENV=test bundle exec rspec spec
+script: RAILS_ENV=test bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -116,6 +116,10 @@ gem 'oneapm_rpm'
 
 gem 'rest-client', '~> 1.8.0'
 
+group :development do
+  gem 'derailed'
+end
+
 group :development, :test do
   gem 'capistrano', '2.9.0', require: false
   gem 'capistrano-unicorn'
@@ -130,7 +134,6 @@ group :development, :test do
   gem 'api_taster', '0.6.0'
 
   gem 'jasmine-rails', '~> 0.10.2'
-  gem 'derailed'
 
   gem 'colorize'
   gem 'letter_opener'

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'coffee-rails'
 gem 'uglifier'
 gem 'jquery-rails', '~> 4.0.4'
 gem 'jbuilder'
-gem 'turbolinks', github: 'rails/turbolinks'
+gem 'turbolinks', git: 'https://github.com/rails/turbolinks.git'
 gem 'jquery-turbolinks'
 
 gem 'actionpack-action_caching', '1.1.1'
@@ -113,6 +113,8 @@ gem 'rack-mini-profiler', require: false
 # gem 'newrelic-grape'
 
 gem 'oneapm_rpm'
+
+gem 'rest-client', '~> 1.8.0'
 
 group :development, :test do
   gem 'capistrano', '2.9.0', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -142,4 +142,6 @@ group :development, :test do
   gem 'binding_of_caller'
 
   gem 'tunemygc'
+
+  gem 'bundler-audit', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,9 @@ GEM
       sass (~> 3.2)
     bson (3.2.6)
     builder (3.2.2)
+    bundler-audit (0.4.0)
+      bundler (~> 1.2)
+      thor (~> 0.18)
     cancancan (1.8.4)
     capistrano (2.9.0)
       highline
@@ -440,6 +443,7 @@ DEPENDENCIES
   auto-space (= 0.0.4)
   better_errors
   binding_of_caller
+  bundler-audit
   cancancan (~> 1.8.4)
   capistrano (= 2.9.0)
   capistrano-sidekiq

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
-  remote: git://github.com/rails/turbolinks.git
-  revision: 83d4b3d2c52a681f07900c28adb28bc8da604733
+  remote: https://github.com/rails/turbolinks.git
+  revision: 90d4132be6275edd997beeb66bf3876b0207291d
   specs:
     turbolinks (3.0.0)
       coffee-rails
@@ -142,6 +142,8 @@ GEM
     devise-encryptable (0.1.2)
       devise (>= 2.1.0)
     diff-lcs (1.2.5)
+    domain_name (0.5.25)
+      unf (>= 0.0.5, < 1.0.0)
     doorkeeper (2.2.1)
       railties (>= 3.2)
     doorkeeper-i18n (2.0.0)
@@ -178,6 +180,8 @@ GEM
     heapy (0.1.1)
     highline (1.7.3)
     hiredis (0.6.0)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
     http_accept_language (2.0.5)
     httpauth (0.2.1)
     i18n (0.7.0)
@@ -246,7 +250,7 @@ GEM
     net-ssh (2.9.2)
     net-ssh-gateway (1.2.0)
       net-ssh (>= 2.6.5)
-    netrc (0.7.7)
+    netrc (0.11.0)
     nokogiri (1.6.5)
       mini_portile (~> 0.6.0)
     oauth2 (0.8.1)
@@ -337,7 +341,8 @@ GEM
     remotipart (1.2.1)
     responders (2.1.0)
       railties (>= 4.2.0, < 5)
-    rest-client (1.7.2)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
     rouge (1.8.0)
@@ -407,6 +412,9 @@ GEM
     uglifier (2.7.2)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.1)
     unicorn (5.0.0)
       kgio (~> 2.6)
       rack
@@ -487,6 +495,7 @@ DEPENDENCIES
   redis (~> 3.2.1)
   redis-namespace (~> 1.5.1)
   redis-objects (= 1.1.0)
+  rest-client (~> 1.8.0)
   rouge (~> 1.8.0)
   rspec-rails (~> 3.3)
   rubocop

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ $ rails s
 ## Testing
 
 ```bash
-bundle exec rspec spec
+bundle exec rake
 ```
 
 ## Contributors

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,12 @@
+#!/usr/bin/env rake
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
 require File.expand_path('../config/application', __FILE__)
-require 'rake'
 
 Rails.application.load_tasks
+
+task default: 'bundle:audit'
 
 if Rails.env.development?
   require 'derailed_benchmarks'
@@ -19,3 +21,4 @@ namespace :test do
     end
   end
 end
+

--- a/Rakefile
+++ b/Rakefile
@@ -8,11 +8,6 @@ Rails.application.load_tasks
 
 task default: 'bundle:audit'
 
-if Rails.env.development?
-  require 'derailed_benchmarks'
-  require 'derailed_benchmarks/tasks'
-end
-
 namespace :test do
   desc 'preparing config files...'
   task :prepare do
@@ -21,4 +16,3 @@ namespace :test do
     end
   end
 end
-

--- a/Rakefile
+++ b/Rakefile
@@ -7,12 +7,3 @@ require File.expand_path('../config/application', __FILE__)
 Rails.application.load_tasks
 
 task default: 'bundle:audit'
-
-namespace :test do
-  desc 'preparing config files...'
-  task :prepare do
-    %w(config mongoid redis).each do |cfgfile|
-      system("cp config/#{cfgfile}.yml.default config/#{cfgfile}.yml") unless File.exist?("config/#{cfgfile}.yml")
-    end
-  end
-end

--- a/lib/tasks/bundler_audit.rake
+++ b/lib/tasks/bundler_audit.rake
@@ -1,0 +1,12 @@
+if Rails.env.development? || Rails.env.test?
+  require 'bundler/audit/cli'
+
+  namespace :bundle do
+    desc 'Updates the ruby-advisory-db and runs audit'
+    task :audit do
+      %w(update check).each do |command|
+        Bundler::Audit::CLI.start [command]
+      end
+    end
+  end
+end

--- a/lib/tasks/test_prepare.rake
+++ b/lib/tasks/test_prepare.rake
@@ -1,0 +1,8 @@
+namespace :test do
+  desc 'preparing config files...'
+  task :prepare do
+    %w(config mongoid redis).each do |cfgfile|
+      system("cp config/#{cfgfile}.yml.default config/#{cfgfile}.yml") unless File.exist?("config/#{cfgfile}.yml")
+    end
+  end
+end


### PR DESCRIPTION
This Pull Request: 

- Install rest-client 1.8.0

  ```
  Name: rest-client
  Version: 1.7.2
  Advisory: CVE-2015-1820
  Criticality: Unknown
  URL: https://github.com/rest-client/rest-client/issues/369
  Title: rubygem-rest-client: session fixation vulnerability via Set-Cookie headers in 30x redirection responses
  Solution: upgrade to >= 1.8.0

  Name: rest-client
  Version: 1.7.2
  Advisory: CVE-2015-3448
  Criticality: Unknown
  URL: http://www.osvdb.org/show/osvdb/117461
  Title: Rest-Client Gem for Ruby logs password information in plaintext
  Solution: upgrade to >= 1.7.3

  Vulnerabilities found!
  ```

- Install turbolinks from secure source and upgrade turbolinks ([CHANGES](https://github.com/rails/turbolinks/compare/83d4b3d...90d4132b))

  ```
  Insecure Source URI found: git://github.com/rails/turbolinks.git
  ```

- Introduce `rake bundle:audit` task to find vulnerable gem
- Hook `rake bundle:audit` into `rake`
- Run tests with `rake` now so that CI will failed if install vulenerable gems

  [<img width="685" alt="screenshot 2015-11-06 14 48 34" src="https://cloud.githubusercontent.com/assets/1000669/10991125/81db3120-8495-11e5-8b0b-6ea176a0e67e.png">](https://travis-ci.org/ruby-china/ruby-china/builds/89589633)

- Cleanup Rakefile
  * Install derailed from development group
  * Move `rake test:prepare` to a standalone file