### PR TITLE
Fix bug, sidebar 中的按钮和帖子底部颜色不同步。

### DIFF
--- a/app/views/topics/_topic_sidebar.html.erb
+++ b/app/views/topics/_topic_sidebar.html.erb
@@ -6,7 +6,7 @@
         <div class="group likes opts">
           <%= likeable_tag(@topic) %>
         </div>
-        <div class="group">
+        <div class="group opts">
           <div class="btn-group" role="group">
             <%= topic_follow_tag(@topic, class: 'btn btn-default') %>
             <%= topic_favorite_tag(@topic, class: 'btn btn-default') %>


### PR DESCRIPTION
点击 sidebar 中的按钮，按钮状态颜色和帖子底部按钮不同步。
![image](https://cloud.githubusercontent.com/assets/341526/10993535/7b4aaf38-84aa-11e5-9507-68da1c30519c.png)