### PR TITLE
不能发帖的用户，上传图像后，不应显示 have_no_avatar 消息

### DIFF
--- a/app/views/topics/_sidebar_for_topic_index.html.erb
+++ b/app/views/topics/_sidebar_for_topic_index.html.erb
@@ -21,7 +21,7 @@
     </div>
   <% end %>
 <% else %>
-  <% if current_user %>
+  <% if current_user && !current_user.avatar? %>
   <div class="panel panel-default clearfix">
     <div class="panel-body">
       <p><%= t('topics.have_no_avatar')%></p>


### PR DESCRIPTION
修复 创建新用户，上传头像后，依然有提示要上传头像的信息
