### PR TITLE
Fix vagrant provision and bin/setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ MongoDB 2.0+                                                               [Yes]
 Redis 2.0+                                                                 [Yes]
 Memcached 1.4+                                                             [Yes]
 ImageMagick 6.5+                                                           [Yes]
-Elasticsearch 2.0                                                          [Yes]
 --------------------------------------------------------------------------------
 
 Installing dependencies

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,4 +6,8 @@ Vagrant.configure(2) do |config|
   config.vm.hostname = "ruby-china-dev"
   config.vm.network "forwarded_port", guest: 3000, host: 3000
   config.vm.provision "shell", path: "bin/provision.sh", privileged: false
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = "1024"
+  end
 end

--- a/bin/provision.sh
+++ b/bin/provision.sh
@@ -4,14 +4,32 @@ sudo update-locale LC_ALL="en_US.utf8"
 sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
 echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list
 
-# Add Ruby sources
-sudo apt-add-repository -y ppa:brightbox/ruby-ng
+# Add Elasticsearch sources
+wget -qO - https://packages.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add -
+echo "deb http://packages.elastic.co/elasticsearch/2.x/debian stable main" | sudo tee -a /etc/apt/sources.list.d/elasticsearch-2.x.list
 
 sudo apt-get update
 sudo apt-get upgrade -y
-sudo apt-get install -y git redis-server memcached imagemagick mongodb-10gen ruby2.2 ruby2.2-dev nodejs
+sudo apt-get install -y git \
+                        redis-server \
+                        memcached \
+                        imagemagick \
+                        mongodb-10gen \
+                        nodejs \
+                        elasticsearch \
+                        openjdk-7-jre-headless
+
+sudo update-rc.d elasticsearch defaults
+sudo service elasticsearch start
+
+# Insall ruby
+gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
+\curl -sSL https://get.rvm.io | bash -s stable
+source /home/vagrant/.rvm/scripts/rvm
+rvm get head
+rvm install 2.3
 
 gem sources --add https://ruby.taobao.org/ --remove https://rubygems.org/
 
-sudo gem install bundler
+gem install bundler
 bundle config mirror.https://rubygems.org https://ruby.taobao.org

--- a/bin/setup
+++ b/bin/setup
@@ -66,7 +66,7 @@ Dir.chdir APP_ROOT do
 
   puts_section 'Checking Package Dependencies...' do
     pkg_exist = true
-    [['mongod', 'MongoDB 2.0+'], ['redis-server', 'Redis 2.0+'], ['memcached', 'Memcached 1.4+'], ['convert', 'ImageMagick 6.5+'], ['elasticsearch', 'Elasticsearch']].each do |item|
+    [['mongod', 'MongoDB 2.0+'], ['redis-server', 'Redis 2.0+'], ['memcached', 'Memcached 1.4+'], ['convert', 'ImageMagick 6.5+']].each do |item|
       puts_line_with_yn item[1] do
         if `which #{item[0]}` == ''
           pkg_exist = false
@@ -105,7 +105,7 @@ Dir.chdir APP_ROOT do
     print 'Your Elasticsearch host (default: 127.0.0.1:9200):'
     host = gets.strip
     host = '127.0.0.1:9200' if host == ''
-    replace_file('config/elasticsearch.yml', '127.0.0.1:9200', host
+    replace_file('config/elasticsearch.yml', '127.0.0.1:9200', host)
   end
 
   puts_line 'Seed default data...' do


### PR DESCRIPTION
- vagrant provision 添加 elasticsearch。
- vagrant provision 改用 rvm 安装 ruby（2.3 PPA 没有 12.04 的包）。
- elasticsearch 没有把可执行文件放到 path，所以 setup 脚本里面的安装检测用不了。
- setup 漏了个括号。