### PR TITLE
add to_i to Array and Hash

### DIFF
--- a/config/initializers/core_ext.rb
+++ b/config/initializers/core_ext.rb
@@ -1,0 +1,12 @@
+
+class Array
+  def to_i
+    0
+  end
+end
+
+class Hash
+  def to_i
+    0
+  end
+end


### PR DESCRIPTION
访问下面的两个链接时会出错
https://ruby-china.org/topics?page[]=2
https://ruby-china.org/topics?page[x]=2

这种时候params[:page] 被解析成Array和Hash，而Array和Hash没有to_i方法，这时候 parmas[:page].to_i 就出错了。

直接加上to_i方法，应该没有什么问题。