### PR TITLE
fix devise translation

### DIFF
--- a/config/locales/devise.zh-CN.yml
+++ b/config/locales/devise.zh-CN.yml
@@ -29,10 +29,11 @@
     confirmations:
       send_instructions: '稍后，您将收到帐号激活的电子邮件。'
       confirmed: '您的帐号已经激活，请登录。'
-    account:
-      signed_up: '您的帐号已注册成功，如无意外，您将收到一封确认邮件。'
-      updated: '帐号资料更新成功。'
-      destroyed: '再见！您的帐户已成功注销。我们希望很快可以再见到您。'
+    registrations:
+      user:
+        signed_up: '您的帐号已注册成功，如无意外，您将收到一封确认邮件。'
+        updated: '帐号资料更新成功。'
+        destroyed: '再见！您的帐户已成功注销。我们希望很快可以再见到您。'
     unlocks:
       send_instructions: '稍后，您将收到一封帐号解锁的邮件。'
       unlocked: '您的帐号已成功解锁，请登录。'

--- a/config/locales/devise.zh-TW.yml
+++ b/config/locales/devise.zh-TW.yml
@@ -29,10 +29,11 @@
     confirmations:
       send_instructions: '稍後，您將收到帳號激活的電子郵件。'
       confirmed: '您的帳號已經激活，請登錄。'
-    account:
-      signed_up: '您的帳號已註冊成功，如無意外，您將收到一封確認郵件。'
-      updated: '帳號資料更新成功。'
-      destroyed: '再見！您的帳戶已成功註銷。我們希望很快可以再見到您。'
+    registrations:
+      user:
+        signed_up: '您的帳號已註冊成功，如無意外，您將收到一封確認郵件。'
+        updated: '帳號資料更新成功。'
+        destroyed: '再見！您的帳戶已成功註銷。我們希望很快可以再見到您。'
     unlocks:
       send_instructions: '稍後，您將收到一封帳號解鎖的郵件。'
       unlocked: '您的帳號已成功解鎖，請登錄。'


### PR DESCRIPTION
![61424bfb-770c-41ce-abe9-9b538c374cca](https://cloud.githubusercontent.com/assets/3198439/12544122/d4af68a6-c371-11e5-904e-6ced1e8ac09d.png)

![96d2331d-3864-4e76-923e-e2c0ceee1cd0](https://cloud.githubusercontent.com/assets/3198439/12544150/1d61fd48-c372-11e5-8714-f7eea9680e67.png)
devise 升级以后 默认写死在 Devise::RegistrationsController里了 可以通过方法覆盖 或者穿scope参数