### PR TITLE
简化 vagrant 安装脚本，修复 db/schema.rb

### DIFF
--- a/bin/provision.sh
+++ b/bin/provision.sh
@@ -5,20 +5,8 @@ wget -qO - https://packages.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add 
 echo "deb http://packages.elastic.co/elasticsearch/2.x/debian stable main" | sudo tee -a /etc/apt/sources.list.d/elasticsearch-2.x.list
 
 # Add PG sources
-APP_DB_USER=admin
-APP_DB_PASS=admin
-PG_VERSION=9.4
-export DEBIAN_FRONTEND=noninteractive
-
-PG_REPO_APT_SOURCE=/etc/apt/sources.list.d/pgdg.list
-if [ ! -f "$PG_REPO_APT_SOURCE" ]
-then
-  # Add PG apt repo:
-  echo "deb http://apt.postgresql.org/pub/repos/apt/ precise-pgdg main" | sudo tee -a "$PG_REPO_APT_SOURCE"
-
-  # Add PGDG repo key:
-  wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-fi
+echo "deb http://apt.postgresql.org/pub/repos/apt/ precise-pgdg main" | sudo tee -a /etc/apt/sources.list.d/pgdb.list
+wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
 
 sudo apt-get update
 sudo apt-get upgrade -y
@@ -28,28 +16,14 @@ sudo apt-get install -y git \
                         imagemagick \
                         nodejs \
                         libpq-dev \
-                        "postgresql-$PG_VERSION" \
-                        "postgresql-contrib-$PG_VERSION" \
+                        postgresql-9.4 \
                         elasticsearch \
                         openjdk-7-jre-headless
 
-PG_CONF="/etc/postgresql/$PG_VERSION/main/postgresql.conf"
-PG_HBA="/etc/postgresql/$PG_VERSION/main/pg_hba.conf"
-PG_DIR="/var/lib/postgresql/$PG_VERSION/main"
-
-sudo sed -i "s/#listen_addresses = 'localhost'/listen_addresses = '*'/" "$PG_CONF"
-echo "host    all             all             all                     md5" | sudo tee -a "$PG_HBA"
-echo "client_encoding = utf8" | sudo tee -a "$PG_CONF"
-sudo service postgresql restart
-
-cat << EOF | sudo su postgres -c psql
--- Create the database user:
-CREATE USER "$APP_DB_USER" WITH CREATEDB PASSWORD '$APP_DB_PASS';
-EOF
-
-
 sudo update-rc.d elasticsearch defaults
 sudo service elasticsearch start
+
+sudo su postgres -c "createuser -d -R -S $USER"
 
 # Insall ruby
 gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3

--- a/bin/setup
+++ b/bin/setup
@@ -100,7 +100,7 @@ Dir.chdir APP_ROOT do
   end
 
   puts_line 'Seed default data...' do
-    `bundle exec rake db:create db:migrate db:seed`
+    `bundle exec rake db:setup`
   end
 
   puts "\n== Removing old logs and tempfiles =="

--- a/config/database.yml.default
+++ b/config/database.yml.default
@@ -16,17 +16,11 @@ production:
 #
 development:
   <<: *default
-  host: localhost
   database: ruby-china-dev
-  username: admin
-  password: admin
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  host: localhost
   database: ruby-china-test
-  username: admin
-  password: admin

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -57,12 +57,6 @@ ActiveRecord::Schema.define(version: 20160126061903) do
 
   add_index "locations", ["name"], name: "index_locations_on_name", using: :btree
 
-  create_table "monkeys", force: :cascade do |t|
-    t.string   "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
   create_table "nodes", force: :cascade do |t|
     t.string   "name",                     null: false
     t.string   "summary"
@@ -207,6 +201,8 @@ ActiveRecord::Schema.define(version: 20160126061903) do
     t.datetime "updated_at"
   end
 
+  add_index "replies", ["deleted_at"], name: "index_replies_on_deleted_at", using: :btree
+  add_index "replies", ["topic_id", "deleted_at"], name: "index_replies_on_topic_id_and_deleted_at", using: :btree
   add_index "replies", ["topic_id"], name: "index_replies_on_topic_id", using: :btree
   add_index "replies", ["user_id"], name: "index_replies_on_user_id", using: :btree
 
@@ -250,16 +246,10 @@ ActiveRecord::Schema.define(version: 20160126061903) do
     t.datetime "updated_at"
   end
 
+  add_index "sites", ["deleted_at"], name: "index_sites_on_deleted_at", using: :btree
+  add_index "sites", ["site_node_id", "deleted_at"], name: "index_sites_on_site_node_id_and_deleted_at", using: :btree
   add_index "sites", ["site_node_id"], name: "index_sites_on_site_node_id", using: :btree
   add_index "sites", ["url"], name: "index_sites_on_url", using: :btree
-
-  create_table "test_documents", force: :cascade do |t|
-    t.integer  "user_id"
-    t.integer  "mentioned_user_ids", default: [],              array: true
-    t.text     "body"
-    t.datetime "created_at",                      null: false
-    t.datetime "updated_at",                      null: false
-  end
 
   create_table "topics", force: :cascade do |t|
     t.integer  "user_id",                               null: false
@@ -287,9 +277,11 @@ ActiveRecord::Schema.define(version: 20160126061903) do
     t.datetime "updated_at"
   end
 
+  add_index "topics", ["deleted_at"], name: "index_topics_on_deleted_at", using: :btree
   add_index "topics", ["excellent"], name: "index_topics_on_excellent", using: :btree
   add_index "topics", ["last_active_mark"], name: "index_topics_on_last_active_mark", using: :btree
   add_index "topics", ["likes_count"], name: "index_topics_on_likes_count", using: :btree
+  add_index "topics", ["node_id", "deleted_at"], name: "index_topics_on_node_id_and_deleted_at", using: :btree
   add_index "topics", ["node_id"], name: "index_topics_on_node_id", using: :btree
   add_index "topics", ["suggested_at"], name: "index_topics_on_suggested_at", using: :btree
   add_index "topics", ["user_id"], name: "index_topics_on_user_id", using: :btree
@@ -343,13 +335,5 @@ ActiveRecord::Schema.define(version: 20160126061903) do
   add_index "users", ["location"], name: "index_users_on_location", using: :btree
   add_index "users", ["login"], name: "index_users_on_login", using: :btree
   add_index "users", ["private_token"], name: "index_users_on_private_token", using: :btree
-
-  create_table "walking_deads", force: :cascade do |t|
-    t.string   "name"
-    t.string   "tag"
-    t.datetime "deleted_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
 
 end


### PR DESCRIPTION
- 简化安装脚本。
- 创建一个有创建删除数据库权限的 pg 用户 vagrant。
- 修复 schema.rb 和 migration 结果不一致。