### PR TITLE
Fix like query broken bug

### DIFF
--- a/app/controllers/cpanel/sites_controller.rb
+++ b/app/controllers/cpanel/sites_controller.rb
@@ -3,7 +3,7 @@ module Cpanel
     def index
       @sites = Site.unscoped.recent.includes(:user, :site_node)
       if params[:q]
-        @sites = @sites.where(name: /#{params[:q]}/)
+        @sites = @sites.where('name LIKE ?',"%#{params[:q]}%")
       end
       @sites = @sites.paginate(page: params[:page], per_page: 20)
 

--- a/app/controllers/cpanel/users_controller.rb
+++ b/app/controllers/cpanel/users_controller.rb
@@ -3,7 +3,7 @@ module Cpanel
     def index
       @users = User.all
       if params[:q]
-        @users = @users.where(login: /#{params[:q]}/)
+        @users = @users.where('login LIKE ?', "%#{params[:q]}%")
       end
       @users = @users.order(id: :desc).paginate page: params[:page], per_page: 30
     end


### PR DESCRIPTION
总感觉在 controller 这样直接写 sql 语句不是很好，想抽一个 共有的方法 query 方法到 `ApplicationRecord` 里面。 但是目前只有 2 个地方有 like 查询，所以犹豫和纠结了。