### PR TITLE
[Discuss & DMN]  Add camo for markdown image

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -118,6 +118,8 @@ gem 'rack-mini-profiler', github: 'MiniProfiler/rack-mini-profiler', require: fa
 
 gem 'oneapm_rpm'
 
+gem 'camo'
+
 group :development do
   gem 'capistrano', '2.9.0', require: false
   gem 'rvm-capistrano', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,7 @@ GEM
     bundler-audit (0.4.0)
       bundler (~> 1.2)
       thor (~> 0.18)
+    camo (0.0.2)
     cancancan (1.13.1)
     capistrano (2.9.0)
       highline
@@ -437,6 +438,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   bundler-audit
+  camo
   cancancan (~> 1.13.1)
   capistrano (= 2.9.0)
   capistrano-sidekiq

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -37,6 +37,7 @@ task :link_shared, roles: :web do
   run "ln -sf #{shared_path}/assets #{current_path}/public/assets"
   run "ln -sf #{shared_path}/config/*.yml #{current_path}/config/"
   run "ln -sf #{shared_path}/config/initializers/secret_token.rb #{current_path}/config/initializers"
+  run "ln -sf #{shared_path}/config/initializers/camo.rb #{current_path}/config/initializers"
   run "ln -sf #{shared_path}/pids #{current_path}/tmp/"
   run "ln -sf #{shared_path}/cache #{current_path}/tmp/"
 end
@@ -68,4 +69,3 @@ after 'deploy:finalize_update', 'deploy:symlink', :link_shared#, :migrate_db, :c
 after 'deploy:start', 'cable:start'
 after 'deploy:restart', 'cable:restart'
 after 'deploy:stop', 'cable:stop'
-

--- a/config/initializers/camo.rb
+++ b/config/initializers/camo.rb
@@ -1,0 +1,2 @@
+ENV["CAMO_HOST"] = "https://ruby-china-camo.herokuapp.com"
+ENV["CAMO_KEY"] = "41aa62f4f97cce01e27ee5985fddea8d9509dc333651342ec39a229fd890034e"

--- a/lib/markdown.rb
+++ b/lib/markdown.rb
@@ -9,6 +9,7 @@ module Redcarpet
   module Render
     class HTMLwithSyntaxHighlight < HTML
       include Rouge::Plugins::Redcarpet
+      include Camo
 
       def initialize(extensions = {})
         super(extensions.merge(xhtml: true,
@@ -36,7 +37,7 @@ module Redcarpet
       # Example: https://gist.github.com/uupaa/f77d2bcf4dc7a294d109
       def image(link, title, alt_text)
         links = link.split(" ")
-        link = links[0]
+        link = camo(links[0])
         if links.count > 1
           # 原本 Markdown 的 title 部分是需要引号的 ![](foo.jpg "Title")
           # ![](foo.jpg =300x)

--- a/spec/lib/markdown_spec.rb
+++ b/spec/lib/markdown_spec.rb
@@ -77,47 +77,49 @@ describe 'markdown' do
 
     describe 'image' do
       subject { super().inner_html }
+      let(:foo_image_url) { 'https://ruby-china-camo.herokuapp.com/01118da590fd3d42b7cc8a19c33e0e175616a479/666f6f2e6a7067' }
 
       context 'simple image' do
         let(:raw) { '![](foo.jpg)' }
 
-        it { is_expected.to eq(%(<p><img src="foo.jpg" title="" alt=""></p>)) }
+        it { is_expected.to eq(%(<p><img src="#{foo_image_url}" title="" alt=""></p>)) }
       end
 
       context 'image with a title' do
         let(:raw) { '![alt text](foo.jpg "titlebb")' }
 
-        it { is_expected.to eq(%(<p><img src="foo.jpg" title="titlebb" alt="alt text"></p>)) }
+        it { is_expected.to eq(%(<p><img src="#{foo_image_url}" title="titlebb" alt="alt text"></p>)) }
       end
 
       context 'image with a title without quote' do
         let(:raw) { '![alt text](foo.jpg titlebb)' }
 
-        it { is_expected.to eq(%(<p><img src="foo.jpg" title="titlebb" alt="alt text"></p>)) }
+        it { is_expected.to eq(%(<p><img src="#{foo_image_url}" title="titlebb" alt="alt text"></p>)) }
       end
 
       context 'image has width' do
         let(:raw) { '![alt text](foo.jpg =200x)' }
 
-        it { is_expected.to eq(%(<p><img src="foo.jpg" width="200px" alt="alt text"></p>)) }
+        it { is_expected.to eq(%(<p><img src="#{foo_image_url}" width="200px" alt="alt text"></p>)) }
       end
 
       context 'image has height' do
         let(:raw) { '![alt text](foo.jpg =x200)' }
 
-        it { is_expected.to eq(%(<p><img src="foo.jpg" height="200px" alt="alt text"></p>)) }
+        it { is_expected.to eq(%(<p><img src="#{foo_image_url}" height="200px" alt="alt text"></p>)) }
       end
 
       context 'image has width and height' do
         let(:raw) { '![alt text](foo.jpg =100x200)' }
 
-        it { is_expected.to eq(%(<p><img src="foo.jpg" width="100px" height="200px" alt="alt text"></p>)) }
+        it { is_expected.to eq(%(<p><img src="#{foo_image_url}" width="100px" height="200px" alt="alt text"></p>)) }
       end
 
       context 'BBCode Image' do
         let(:raw) { '[img]http://ruby-china.org/logo.png[/img]' }
+        let(:camo_image_url) { 'https://ruby-china-camo.herokuapp.com/0e9e45899127470daad093a361e23554c8aa340f/687474703a2f2f727562792d6368696e612e6f72672f6c6f676f2e706e67' }
 
-        it { is_expected.to eq(%(<p><img src="http://ruby-china.org/logo.png" title="" alt="Logo"></p>))}
+        it { is_expected.to eq(%(<p><img src="#{camo_image_url}" title="" alt="Logo"></p>))}
       end
     end
 


### PR DESCRIPTION
#512 

根据 @huobazi 的建议，模仿 github 加上了 camo, 作为图片的代理, 这个可以解决页面中有非 https 协议的图片带来的安全警告问题。
 
部署过程： 
1. 配置 camo.rb 文件
2. 生产服务器上运行 [camo](!https://github.com/atmos/camo) 程序
3. 又拍云需要新建一个仓库，作为 camo 图片的缓存。
问题： 
1. 是否要将 camo 程序的启动做到 cap 里面。
2. 是否需要监控？
(如果有个 camo 自启动脚本，可能就不需要这些了，当成类似依赖的服务好了)

cc @huacnlee @huobazi