### PR TITLE
在提交时禁用'提交回复'按钮，避免重复提交

### DIFF
--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -78,7 +78,7 @@
             <%= f.text_area :body, class: "topic-editor form-control", rows: "4", tabindex: "1" %>
           </div>
           <div class="submit-buttons">
-            <button type="submit" id="reply-button" class="btn btn-primary" tabindex="2"><%= t("topics.submit_reply")%></button>
+            <button type="submit" id="reply-button" class="btn btn-primary" tabindex="2", data-disable-with='<%= t("topics.submit_reply") %>'><%= t("topics.submit_reply")%></button>
             <span class="help-inline" style="padding-left: 5px;" title="或者 Ctrl + Enter"><kbd>Command</kbd> + <kbd>Enter</kbd></span>
 
             <div class="pull-right"><a href="/markdown" target="_blank">排版说明</a></div>


### PR DESCRIPTION
原因：在 Topics#show 页面 reply 时， '提交回复' 按钮没有disable，连续点击就会提交多条相同的回复，而且没有提示说明正在提交。

但由于我不明白一行 JS 代码：`$('#reply-button').button('reset')`，
在这行代码后面好像就不能修改`#reply-button`的 text ，在这行前面就可以，
请问是什么意思？这行代码在：[app/assets/javascripts/topics.coffee#L212](https://github.com/ruby-china/ruby-china/blob/master/app/assets/javascripts/topics.coffee#L212)

所以我加的 disable-with 用了 '提交回复' （而不是类似'提交中...'，然后在 Ajax 返回后再替换按钮文字。）