### PR TITLE
upgrade rubocop to 0.39.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 AllCops:
-  RunRailsCops: true
+  Rails:
+    Enabled: true
   Exclude:
     - 'lib/templates/**/*'
     - 'lib/ftp_sync.rb'
@@ -47,7 +48,4 @@ Rails/FindBy:
   Enabled: false
 
 Rails/HasAndBelongsToMany:
-  Enabled: false
-
-Rails/DefaultScope:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -138,7 +138,7 @@ group :development do
 end
 
 group :development, :test do
-  gem 'rubocop'
+  gem 'rubocop', '~> 0.39.0', require: false
   gem 'rspec-rails', '3.5.0.beta1'
   gem 'factory_girl_rails', '~> 4.5.0'
   gem 'database_cleaner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -282,7 +282,7 @@ GEM
     oneapm_rpm (1.3.4)
     orm_adapter (0.5.0)
     parallel (1.6.1)
-    parser (2.3.0.2)
+    parser (2.3.0.7)
       ast (~> 2.2)
     pg (0.18.4)
     phantomjs (2.1.1.0)
@@ -377,11 +377,12 @@ GEM
       rspec-mocks (= 3.5.0.beta1)
       rspec-support (= 3.5.0.beta1)
     rspec-support (3.5.0.beta1)
-    rubocop (0.36.0)
-      parser (>= 2.3.0.0, < 3.0)
+    rubocop (0.39.0)
+      parser (>= 2.3.0.7, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.7.5)
     ruby-push-notifications (0.3.1)
       builder (~> 3.0)
@@ -435,6 +436,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.2)
+    unicode-display_width (1.0.3)
     upyun (1.0.9)
       activesupport (>= 3.2.8)
       rest-client (>= 1.6.7)
@@ -520,7 +522,7 @@ DEPENDENCIES
   redis-objects
   rouge (~> 1.8.0)
   rspec-rails (= 3.5.0.beta1)
-  rubocop
+  rubocop (~> 0.39.0)
   ruby-push-notifications
   rucaptcha
   rvm-capistrano


### PR DESCRIPTION
升级 rubocop 以便更好的支持 ruby 2.3 特性。