### PR TITLE
Update devise.zh-CN.yml

### DIFF
--- a/config/locales/devise.zh-CN.yml
+++ b/config/locales/devise.zh-CN.yml
@@ -11,6 +11,7 @@
         failure: '三方登陆过程异常，请重试。'
     failure:
       already_authenticated: '您已经登录。'
+      already_signed_out: '您已经退出。'
       unauthenticated: '继续操作前请注册或者登录。'
       unconfirmed: '请先激活您的帐号。'
       locked: '您的帐号已被锁定。'


### PR DESCRIPTION
连续退出两次会出现翻译缺失：
`translation missing: zh-CN.devise.sessions.user.already_signed_out`
修改了一下_devise.zh-CN.yml_文件