### PR TITLE
add font awesome support to markdown editor

### DIFF
--- a/lib/markdown.rb
+++ b/lib/markdown.rb
@@ -54,6 +54,14 @@ module Redcarpet
         end
       end
 
+      def link(link, title, content)
+        if content.eql?("icon")
+          %(<i class="fa fa-#{link}"></i>)
+        else
+          %(<a href="#{link}" target="_blank">#{content}</a>">)
+        end
+      end
+
       # Fix Chinese neer the URL
       def autolink(link, link_type)
         # return link


### PR DESCRIPTION
只是一个小提议，能不能在编辑器里增加对font-awesome图标的支持，感觉特别在小标题里用会让文章更酷一点。

```ruby
2.3.0 (main):0 > MarkdownTopicConverter.convert("## [icon](pencil)blabla")
=> "<h2 id=\"blabla\"><i class=\"fa fa-pencil\"></i>blabla</h2>"
```