### PR TITLE
update provision

### DIFF
--- a/bin/provision.sh
+++ b/bin/provision.sh
@@ -10,6 +10,7 @@ wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-
 
 # Add Ruby sources
 sudo apt-add-repository ppa:brightbox/ruby-ng
+sudo add-apt-repository ppa:rwky/redis
 
 sudo apt-get update
 sudo apt-get upgrade -y


### PR DESCRIPTION
```
vagrant@ruby-china-dev:/vagrant$ redis-server -v
Redis server version 2.2.12 (00000000:0)
```

old version redis has some problem.

for example, when I run ruby-china, I run into

```
ERR wrong number of arguments for 'zadd' command
```

so update redis.
