### PR TITLE
至顶部与至底部按钮位置互换

### DIFF
--- a/app/views/topics/_topic_sidebar.html.erb
+++ b/app/views/topics/_topic_sidebar.html.erb
@@ -1,7 +1,7 @@
 <div id="topic-sidebar" data-spy="affix" data-offset-bottom="65">
   <div class="panel panel-default">
     <div class="panel-body">
-      <a href="#" class="btn btn-block btn-sm btn-move-page" data-type="top"><i class="fa fa-arrow-up"></i></a>
+      <a href="#" class="btn btn-block btn-move-page" data-type="bottom"><i class="fa fa-arrow-down"></i></a>
       <div class="buttons">
         <div class="group likes opts">
           <%= likeable_tag(@topic) %>
@@ -54,7 +54,7 @@
           <% end %>
         <% end %>
       </div>
-      <a href="#" class="btn btn-block btn-move-page" data-type="bottom"><i class="fa fa-arrow-down"></i></a>
+      <a href="#" class="btn btn-block btn-sm btn-move-page" data-type="top"><i class="fa fa-arrow-up"></i></a>
     </div>
   </div>
 


### PR DESCRIPTION
感觉一般向下滚动时鼠标都在屏幕下方，因此至顶部按钮在下方较为合理。向上滚动时与之相反。