### PR TITLE
Use remote form to submit topics for turbolinks-android

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -115,12 +115,7 @@ class TopicsController < ApplicationController
     @topic.user_id = current_user.id
     @topic.node_id = params[:node] || topic_params[:node_id]
     @topic.team_id = ability_team_id
-
-    if @topic.save
-      redirect_to(topic_path(@topic.id), notice: t('topics.create_topic_success'))
-    else
-      render action: 'new'
-    end
+    @topic.save
   end
 
   def preview

--- a/app/views/topics/_form.html.erb
+++ b/app/views/topics/_form.html.erb
@@ -1,6 +1,6 @@
 <%= render 'node_selector', node: @topic.node %>
 
-<%= simple_form_for @topic, html: { class: "form", tb: 'edit-topic' } do |f| %>
+<%= simple_form_for @topic, remote: true, html: { class: "form", tb: 'edit-topic' } do |f| %>
   <%= render "shared/error_messages", target: @topic %>
   <%= f.hidden_field :node_id %>
 

--- a/app/views/topics/create.js.erb
+++ b/app/views/topics/create.js.erb
@@ -1,0 +1,7 @@
+<% if @topic.errors.empty? %>
+  <% flash[:notice] = t('topics.create_topic_success') %>
+  Turbolinks.visit('<%= topic_path(@topic.id) %>');
+<% else %>
+  $('form[tb="edit-topic"] .alert').remove();
+  $('form[tb="edit-topic"]').prepend('<%= j render("shared/error_messages", target: @topic) %>');
+<% end %>


### PR DESCRIPTION
需要用 xhr 提交表单，不然会导致冷启动。

在 turbolinks-android 下会导致重新打开提交前的页面，不知道 ios 有没有这个问题。