### PR TITLE
Add user mailer spec & Update UserMailer#welcome

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,7 +1,6 @@
 class UserMailer < BaseMailer
-  def welcome(user_id)
-    @user = User.find_by_id(user_id)
-    return false if @user.blank?
+  def welcome(user)
+    @user = user
     mail(to: @user.email, subject: t('mail.welcome_subject', app_name: Setting.app_name).to_s)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -174,7 +174,7 @@ class User < ApplicationRecord
   # 注册邮件提醒
   after_create :send_welcome_mail
   def send_welcome_mail
-    UserMailer.welcome(id).deliver_later
+    UserMailer.welcome(self).deliver_later
   end
 
   # 保存用户所在城市

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe UserMailer, type: :mailer do
+  let(:user) { create :user }
+
+  describe 'welcome' do
+  	let(:mail) { UserMailer.welcome(user) }
+
+    it "renders the headers" do
+      expect(mail.subject).to eq(I18n.t('mail.welcome_subject', app_name: Setting.app_name).to_s)
+      expect(mail.to).to eq([user.email])
+      expect(mail.from).to eq([Setting.email_sender])
+    end
+
+    it "renders the body" do
+      expect(mail.body.encoded).to match(user.fullname)
+    end
+  end
+end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -4,7 +4,7 @@ describe UserMailer, type: :mailer do
   let(:user) { create :user }
 
   describe 'welcome' do
-  	let(:mail) { UserMailer.welcome(user) }
+    let(:mail) { UserMailer.welcome(user) }
 
     it "renders the headers" do
       expect(mail.subject).to eq(I18n.t('mail.welcome_subject', app_name: Setting.app_name).to_s)

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -13,7 +13,7 @@ describe UserMailer, type: :mailer do
     end
 
     it "renders the body" do
-      expect(mail.body.encoded).to match(user.fullname)
+      expect(mail.body.encoded).to match(Regexp.escape user.fullname)
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -605,4 +605,10 @@ describe User, type: :model do
       expect(user.team_collection.collect { |_, id| id }).to include(*(ids1 + ids2))
     end
   end
+
+  describe 'welcome mail' do
+    it 'should send after create' do
+      expect { create :user }.to change{ ActionMailer::Base.deliveries.count }.by(1)
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -607,8 +607,12 @@ describe User, type: :model do
   end
 
   describe 'welcome mail' do
+    let(:user) { build(:user) }
+
     it 'should send after create' do
-      expect { create :user }.to change{ ActionMailer::Base.deliveries.count }.by(1)
+      expect { user.save }.to change{ ActionMailer::Base.deliveries.count }.by(1)
+      mail = ActionMailer::Base.deliveries.last
+      expect(mail.to).to eq([user.email])
     end
   end
 end


### PR DESCRIPTION
`User after_create` 后, 只传递 `user id` 至 `UserMailer#welcome`, 再在其中再次取出这个 `user` 的做法会不会有点奇怪? 

1. 改为直接传递这个 `user instance` 过去.
2. 另外之前没有相关 `spec`, 学习了下加上了, 参考了  [rspec-rails#mailer-specs](https://github.com/rspec/rspec-rails#mailer-specs)