### PR TITLE
[WIP] 分开展示个人会员与团队账号

### DIFF
--- a/app/assets/stylesheets/teams.scss
+++ b/app/assets/stylesheets/teams.scss
@@ -76,3 +76,24 @@
     .buttons { width: 180px; }
   }
 }
+
+#teams {
+  .team {
+    padding: 10px;
+  }
+
+  .team-container {
+    border: 1px dashed #e8e1e1;
+    border-radius: 5px;
+    padding: 10px;
+  }
+
+  .media-object {
+    display: inline-block;
+  }
+
+  .team-member {
+    padding: 0;
+    text-align: center;
+  }
+}

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,6 +1,6 @@
 class TeamsController < ApplicationController
-  load_resource find_by: :login
-  load_and_authorize_resource
+  load_resource find_by: :login, except: [:city]
+  load_and_authorize_resource except: [:city]
 
   before_action :set_team, only: [:show, :edit, :update, :destroy]
 
@@ -10,6 +10,19 @@ class TeamsController < ApplicationController
 
   def show
     redirect_to user_path(params[:id])
+  end
+
+  def city
+    @location = Location.location_find_by_name(params[:id])
+    if @location.blank?
+      render_404
+      return
+    end
+
+    @teams = Team.where(location_id: @location.id).fields_for_list.includes(:users)
+    @teams = @teams.order(replies_count: :desc).paginate(page: params[:page], per_page: 20)
+
+    render_404 if @teams.count == 0
   end
 
   def new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -22,7 +22,7 @@ class UsersController < ApplicationController
       return
     end
 
-    @users = User.where(location_id: @location.id).fields_for_list
+    @users = User.personal.where(location_id: @location.id).fields_for_list
     @users = @users.order(replies_count: :desc).paginate(page: params[:page], per_page: 60)
 
     render_404 if @users.count == 0

--- a/app/helpers/locations_helper.rb
+++ b/app/helpers/locations_helper.rb
@@ -4,4 +4,25 @@ module LocationsHelper
     name = location.is_a?(String) == true ? location : location.name
     link_to(name, location_users_path(name))
   end
+
+  # 地区账号列表页面的链接
+  #
+  # @param location [String] 地区 Location 实例
+  # @param user_type ['user', 'team'] 账号类型
+  # @param _options [Hash] 额外的选项，传递给底层的 link_to 方法
+  #
+  def location_users_link(location, user_type, _options = {})
+    path = if user_type == "user"
+      location_users_path(id: location.name)
+    else
+      location_teams_path(id: location.name)
+    end
+
+    title = user_type == "user" ? "会员" : "团队"
+    if current_page?(path)
+      title
+    else
+      link_to title, path, _options
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -57,6 +57,7 @@ class User < ApplicationRecord
   validates :name, length: { maximum: 20 }
 
   scope :hot, -> { order(replies_count: :desc).order(topics_count: :desc) }
+  scope :personal, -> { where(type: nil) }
   scope :fields_for_list, lambda {
     select(:type, :id, :name, :login, :email, :email_md5, :email_public, :avatar, :verified, :state,
            :tagline, :github, :website, :location, :location_id, :twitter, :co)

--- a/app/views/shared/_location_users_switches.html.erb
+++ b/app/views/shared/_location_users_switches.html.erb
@@ -1,0 +1,5 @@
+<div class="panel-heading">
+  <%= location.name %>的<%= location_users_link(location, 'user') %>
+  &nbsp;|&nbsp;
+  <%= location_users_link(location, 'team') %>
+</div>

--- a/app/views/teams/city.html.erb
+++ b/app/views/teams/city.html.erb
@@ -1,0 +1,34 @@
+<% title_tag @location.name %>
+
+<div id="teams" class="box">
+  <div id="hot_teams" class="panel panel-default user-list">
+    <%= render "shared/location_users_switches", location: @location %>
+    <div class="panel-body row">
+      <% if !@teams.blank? %>
+        <% @teams.each do |item| %>
+          <div class="team col-sm-3">
+            <div class="team-container">
+              <div class="team-banner">
+                <div class="avatar col-xs-2 col-md-3"><%= user_avatar_tag(item, :md) %></div>
+                <div class="name col-xs-10  col-md-9"><%= user_name_tag(item) %></div>
+                <div class="clearfix"></div>
+              </div>
+              <hr>
+              <div class="team-members">
+                <% item.users[0..5].each do |user| %>
+                  <div class="team-member col-xs-2">
+                    <%= user_avatar_tag(user, :sm) %>
+                  </div>
+                <% end %>
+                <div class="clearfix"></div>
+              </div>
+            </div>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+    <div class="panel-footer clearfix">
+      <%= will_paginate @teams %>
+    </div>
+  </div>
+</div>

--- a/app/views/users/city.html.erb
+++ b/app/views/users/city.html.erb
@@ -2,7 +2,7 @@
 
 <div id="users" class="box">
   <div id="hot_users" class="panel panel-default user-list">
-    <div class="panel-heading"><%= @location.name %>的会员</div>
+    <%= render "shared/location_users_switches", location: @location %>
     <div class="panel-body row">
       <% if !@users.blank? %>
       <% @users.each do |item| %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,9 @@ Rails.application.routes.draw do
     end
   end
   resources :devices
-  resources :teams
+  resources :teams do
+    get "/city/:id", action: "city", on: :collection, as: "location"
+  end
 
   root to: 'home#index'
 


### PR DESCRIPTION
原来的会员列表中，会混合个人会员与团队，团队在名称比较长的时候会打乱布局：

![image](https://cloud.githubusercontent.com/assets/2900644/18016800/e38f674e-6c00-11e6-8dad-b87f77204a1b.png)

这个分支做的是在同一地区将个人账号与团队账号分开显示，支持切换，效果请看录屏：
![ruby-china](https://cloud.githubusercontent.com/assets/2900644/18016990/c8ca5a30-6c01-11e6-9eb5-05df0f5e9346.gif)

提前申请 PR 是为了方便大家一起讨论以上功能是否必要，目前还有以下工作未完成：
1. 完善测试用例；
2. 处理部分地区下无团队账号的异常情况。