### PR TITLE
fix header search input value not match q params bug

### DIFF
--- a/app/assets/javascripts/app.coffee
+++ b/app/assets/javascripts/app.coffee
@@ -46,6 +46,7 @@ AppView = Backbone.View.extend
     @initComponents()
     @initInfiniteScroll()
     @initCable()
+    @restoreHeaderSearchBox()
 
     if $('body').data('controller-name') in ['topics', 'replies']
       window._topicView = new TopicView({parentView: @})
@@ -160,6 +161,16 @@ AppView = Backbone.View.extend
       link.removeClass("new")
     span.text(json.count)
     document.title = new_title
+
+  restoreHeaderSearchBox: ->
+    $searchInput = $(".header .form-search input")
+
+    if location.pathname != "/search"
+      $searchInput.val("")
+    else
+      results = new RegExp('[\?&]q=([^&#]*)').exec(window.location.href)
+      q = results && decodeURIComponent(results[1])
+      $searchInput.val(q)
 
   openHeaderSearchBox: (e) ->
     $(".header .form-search").addClass("active")


### PR DESCRIPTION
搜索 `test1`, 再搜索 `test2`, 点击浏览器后退按钮即可重现 bug，
如图：
![screen_shot_2016-09-12_at_10_58_36_pm](https://cloud.githubusercontent.com/assets/1459834/18440686/aa745372-793c-11e6-8de8-1887fe37ca78.png)
