### PR TITLE
refactor user state with rails enum

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -66,4 +66,8 @@ class Page < ApplicationRecord
   def self.find_by_slug(slug)
     fetch_by_uniq_keys(slug: slug)
   end
+
+  def as_indexed_json(_options = {})
+    as_json(only: [:title, :body])
+  end
 end

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -18,7 +18,7 @@
   <% if @user.user_type == :user %>
   <%= f.input :verified, as: :boolean, hint: t("admin.users.trust_user_can_modify_wiki") %>
   <%= f.input :hr, as: :boolean, hint: t("admin.users.hr_user_can_create_topic") %>
-  <%= f.input :state, as: :select, collection: User::STATE.collect { |s| [s[0],s[1]] } %>
+  <%= f.input :state, as: :select, collection: User.states.collect { |s| [s[0],s[1]] } %>
   <%= f.input :sign_in_count, readonly: true %>
   <%= f.input :last_sign_in_at, as: :string, readonly: true %>
   <%= f.input :current_sign_in_at, as: :string, readonly: true %>
@@ -39,7 +39,7 @@
   <% end %>
   <div class="form-group">
 
-    <% if @user.state != User::STATE[:deleted] %>
+    <% if @user.deleted? %>
       <div class="pull-right">
         <%= link_to '删除此用户', admin_user_path(@user.id), 'data-confirm' => '警告！此动作无法撤销，确定要删除么?', method: :delete, class: "btn btn-danger"  %>
       </div>

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe UsersController, type: :controller do
   let(:user) { create :user, location: 'Shanghai' }
-  let(:deleted_user) { create :user, state: User::STATE[:deleted] }
+  let(:deleted_user) { create :user, state: User.states[:deleted] }
 
   describe 'Visit deleted user' do
     it 'should 404 with deleted user' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -102,10 +102,10 @@ describe User, type: :model do
     it 'user can soft_delete' do
       user_for_delete1.soft_delete
       user_for_delete1.reload
-      expect(user_for_delete1.state).to eq(-1)
+      expect(user_for_delete1.state).to eq('deleted')
       user_for_delete2.soft_delete
       user_for_delete1.reload
-      expect(user_for_delete1.state).to eq(-1)
+      expect(user_for_delete1.state).to eq('deleted')
       expect(user_for_delete1.authorizations).to eq([])
     end
   end


### PR DESCRIPTION
代码实现功能：

1. update user state with rails enum.
2. update elasticsearch model index.

一些疑问： 
根据 search_controller/index 的实现：
```ruby

  def index
    search_params = {
      query: {
        simple_query_string: {
          query: params[:q],
          default_operator: 'AND',
          minimum_should_match: '70%',
          fields: %w(title body name login)
        }
      },
      highlight: {
        pre_tags: ['[h]'],
        post_tags: ['[/h]'],
        fields: { title: {}, body: {}, name: {}, login: {} }
      }
    }
    @result = Elasticsearch::Model.search(search_params, [Topic, User, Page]).paginate(page: params[:page], per_page: 30)
  end
```

应该支持用户的搜索，但是在ruby-china 测试，搜索 user login 没有结果，比如 https://ruby-china.org/search?q=small_fish__  
如图：
![screen shot 2016-09-14 at 3 00 23 pm](https://cloud.githubusercontent.com/assets/1459834/18502817/10ec1e82-7a8c-11e6-914e-966347c8ee12.png)

