### PR TITLE
Test against trunk Ruby instead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,12 @@ services:
 
 rvm:
   - 2.3.1
-  - ruby-2.4.0-preview1
+  - ruby-head
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - rvm: ruby-head
 
 before_script:
   - psql -c "CREATE USER \"admin\" WITH CREATEDB PASSWORD 'admin';" -U postgres


### PR DESCRIPTION
`ruby-head` will automatically points to latest trunk version of Ruby and allow it to fail.