### PR TITLE
add presence validate for location name

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -5,7 +5,7 @@ class Location < ApplicationRecord
 
   scope :hot, -> { order(users_count: :desc) }
 
-  validates :name, uniqueness: { case_sensitive: false }
+  validates :name, presence: true, uniqueness: { case_sensitive: false }
 
   before_save { |loc| loc.name = loc.name.downcase.strip }
 


### PR DESCRIPTION
如果我在 console 中执行, Location.create ,将创建一个 name 为空的记录.
但当访问首页的时候会报错，因为

```
ActionController::UrlGenerationError - No route matches {:action=>"city", :controller=>"users", :id=>""} missing required keys: [:id]:
```

所以我觉得还是给 Location 加个  presence 验证好一点.
