### PR TITLE
Add aliyun oss support.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,8 @@ gem 'bulk_insert'
 # 上传组件
 gem 'carrierwave'
 gem 'carrierwave-upyun'
+# See more details about how to configure aliyun at wiki/Aliyun-OSS-picture-setting
+gem 'carrierwave-aliyun'
 gem 'mini_magick'
 
 # 验证码，头像

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,10 @@ GEM
     addressable (2.4.0)
     airbrussh (1.1.1)
       sshkit (>= 1.6.1, != 1.7.0)
+    aliyun-oss-sdk (0.1.8)
+      addressable
+      gyoku
+      httparty
     arel (7.1.2)
     ast (2.3.0)
     auto-space (0.0.4)
@@ -72,7 +76,7 @@ GEM
       i18n
       rake (>= 10.0.0)
       sshkit (>= 1.9.0)
-    capistrano-bundler (1.1.4)
+    capistrano-bundler (1.2.0)
       capistrano (~> 3.1)
       sshkit (~> 1.2)
     capistrano-harrow (0.5.3)
@@ -101,6 +105,9 @@ GEM
       json (>= 1.7)
       mime-types (>= 1.16)
       mimemagic (>= 0.3.0)
+    carrierwave-aliyun (0.7.0)
+      aliyun-oss-sdk (>= 0.1.6)
+      carrierwave (>= 0.5.7)
     carrierwave-upyun (0.2.1)
       carrierwave (>= 0.5.7)
       faraday (>= 0.8.0)
@@ -177,6 +184,8 @@ GEM
     get_process_mem (0.2.1)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
+    gyoku (1.3.1)
+      builder (>= 2.1.2)
     hashie (3.4.6)
     heapy (0.1.2)
     hiredis (0.6.1)
@@ -188,6 +197,8 @@ GEM
       html-pipeline (>= 1.11)
       rouge (~> 1.8)
     http_accept_language (2.0.5)
+    httparty (0.14.0)
+      multi_xml (>= 0.5.2)
     i18n (0.7.0)
     jasmine-core (2.5.2)
     jasmine-rails (0.10.8)
@@ -203,9 +214,12 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    json (1.8.3)
-    jsonapi (0.1.1.beta2)
-      json (~> 1.8)
+    json (2.0.2)
+    jsonapi (0.1.1.beta5)
+      jsonapi-parser (= 0.1.1.beta2)
+      jsonapi-renderer (= 0.1.1.beta1)
+    jsonapi-parser (0.1.1.beta2)
+    jsonapi-renderer (0.1.1.beta1)
     jwt (1.5.6)
     kgio (2.10.0)
     launchy (2.4.3)
@@ -238,9 +252,8 @@ GEM
       net-ssh (>= 2.6.5)
     net-ssh (3.2.0)
     nio4r (1.2.1)
-    nokogiri (1.6.8)
+    nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
-      pkg-config (~> 1.1.7)
     notifications (0.2.0)
       rails (>= 4.2.0, < 5.1)
       will_paginate (>= 3.0.0)
@@ -265,7 +278,6 @@ GEM
       ast (~> 2.2)
     pg (0.19.0)
     phantomjs (2.1.1.0)
-    pkg-config (1.1.7)
     postmark (1.8.1)
       json
       rake
@@ -398,10 +410,11 @@ GEM
       rack-protection (= 2.0.0.beta2)
       tilt (~> 2.0)
     slop (3.6.0)
-    social-share-button (0.6.0)
+    social-share-button (0.8.0)
       coffee-rails
       sass-rails
-    spring (1.7.2)
+    spring (2.0.0)
+      activesupport (>= 4.2)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
     sprockets (3.7.0)
@@ -457,6 +470,7 @@ DEPENDENCIES
   capistrano3-puma
   capybara
   carrierwave
+  carrierwave-aliyun
   carrierwave-upyun
   codecov
   coffee-rails
@@ -526,4 +540,4 @@ DEPENDENCIES
   will_paginate
 
 BUNDLED WITH
-   1.13.1
+   1.13.2

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -45,7 +45,7 @@ module UsersHelper
     img =
       if user.avatar?
         image_url = user.avatar.url(version)
-        image_url += "?t=#{user.updated_at.to_i}" if opts[:timestamp]
+        image_url += "?t=#{user.updated_at.to_i}" if opts[:timestamp] && Setting.upload_provider == 'upyun'
         image_tag(image_url, class: img_class)
       else
         image_tag(user.letter_avatar_url(width * 2), class: img_class)

--- a/app/uploaders/base_uploader.rb
+++ b/app/uploaders/base_uploader.rb
@@ -30,6 +30,10 @@ class BaseUploader < CarrierWave::Uploader::Base
     unless version_name.in?(ALLOW_VERSIONS)
       raise "ImageUploader version_name:#{version_name} not allow."
     end
-    [@url, version_name].join('!') # thumb split with "!"
+    if Setting.upload_provider == 'aliyun'
+      super(thumb: "@!#{version_name}")
+    else
+      [@url, version_name].join('!') # thumb split with "!"
+    end
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -116,7 +116,7 @@
   <% end %>
   <script type="text/javascript" data-turbolinks-eval="false">
     App.root_url = "<%= main_app.root_url %>";
-    App.asset_url = "<%= Setting.upload_url %>";
+    App.asset_url = "<%= Setting.upload_url -%>";
     App.twemoji_url = "<%= Twemoji.configuration.asset_root %>";
     App.locale = "<%= I18n.locale %>";
     <% if current_user %>

--- a/app/views/layouts/simple.html.erb
+++ b/app/views/layouts/simple.html.erb
@@ -56,7 +56,7 @@
   <% end %>
   <script type="text/javascript" data-turbolinks-eval="false">
     App.root_url = "<%= root_url %>";
-    App.asset_url = "<%= Setting.upload_url %>";
+    App.asset_url = "<%= Setting.upload_url -%>";
     <% if current_user %>
       App.current_user_id = <%= current_user.id %>;
     <% end %>

--- a/config/config.yml.default
+++ b/config/config.yml.default
@@ -63,11 +63,14 @@ defaults: &defaults
   admin_emails:
     - "admin@admin.com"
   google_analytics_key: ""
-  upload_url: "http://ruby-china-files-dev.b0.upaiyun.com"
   asset_host: ""
-  upyun_username: "test"
-  upyun_password: "123123"
-  upyun_bucket: "ruby-china-files-dev"
+  upload_provider: "upyun" # can be  upyun/aliyun
+  upload_access_id: "test" # or username
+  upload_access_secret: "123123"
+  upload_bucket: "ruby-china-files-dev"
+  upload_url: "http://ruby-china-files-dev.b0.upaiyun.com"
+  upload_aliyun_internal: true
+  upload_aliyun_area: "cn-shanghai"
   email_server: "smtp.exmail.qq.com"
   email_sender: 'dev-test@ruby-china.org'
   email_password: 'test123456'

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -25,13 +25,23 @@ CarrierWave.configure do |config|
   if Rails.env.test?
     # http://stackoverflow.com/questions/7534341/rails-3-test-fixtures-with-carrierwave/25315883#25315883
     config.storage NullStorage
-  else
-    config.storage = :upyun
   end
-  # Do not remove previously file after new file uploaded
-  config.remove_previously_stored_files_after_update = false
-  config.upyun_username = Setting.upyun_username
-  config.upyun_password = Setting.upyun_password
-  config.upyun_bucket = Setting.upyun_bucket
-  config.upyun_bucket_host = Setting.upload_url
+  case Setting.upload_provider
+  when 'aliyun'
+    config.storage = :aliyun
+    config.aliyun_access_id  = Setting.upload_access_id
+    config.aliyun_access_key = Setting.upload_access_secret
+    config.aliyun_bucket     = Setting.upload_bucket
+    config.aliyun_internal   = Setting.upload_aliyun_internal.to_s == 'false' ? false : true
+    config.aliyun_area       = Setting.upload_aliyun_area
+    config.aliyun_host       = Setting.upload_url
+  when 'upyun'
+    config.storage = :upyun
+    # Do not remove previously file after new file uploaded
+    config.remove_previously_stored_files_after_update = false
+    config.upyun_username = Setting.upload_access_id
+    config.upyun_password = Setting.upload_access_secret
+    config.upyun_bucket = Setting.upload_bucket
+    config.upyun_bucket_host = Setting.upload_url
+  end
 end


### PR DESCRIPTION
相关讨论可前往[论坛帖子 Ruby China 有没有可能接受一个阿里云 OSS 的兼容性改动？](https://ruby-china.org/topics/31051)

使用aliyun需要配置相应config.yml，然后在阿里云上[设置图片处理及相关样式](/ruby-china/ruby-china/wiki/Aliyun-OSS-picture-setting)。

<img width="708" alt="screen shot 2016-10-01 at 10 56 56 pm" src="https://cloud.githubusercontent.com/assets/1131536/19014861/be96bb40-882a-11e6-990b-c8aff8043508.png">

这个PR对于现有使用又拍云存贮的ruby-china实例是透明的。